### PR TITLE
chore: Pin latest version of bookshelf

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -72,7 +72,7 @@ jobs:
           git push && git push --tags
 
           # Exit early if the version is a pre-release
-          [[ "$NEW_VERSION" =~ ([abrc]?) ]] && exit 0
+          [[ "$NEW_VERSION" =~ ([abrc]+) ]] && exit 0
 
           # Bump to alpha (so that future commits do not have the same
           # version as the tagged commit)

--- a/changelog/110.improvement.md
+++ b/changelog/110.improvement.md
@@ -1,0 +1,1 @@
+Pin bookshelf version for producer

--- a/packages/bookshelf-producer/pyproject.toml
+++ b/packages/bookshelf-producer/pyproject.toml
@@ -8,13 +8,13 @@ dependencies = [
     "click>=8.0.1",
     "click-log>=0.3.2",
     "python-dotenv>=1.0.0",
-    "bookshelf",
+    "bookshelf>=0.3.1b3",
     "seaborn>=0.12.2",
     "papermill>=2.4.0",
     "jupytext>=1.14.7",
     "ipykernel>6.0.0",
     # TODO: remove PRIMAP-hist script dependency
-    "pycountry"
+    "pycountry>=24.6.1"
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -389,7 +389,7 @@ requires-dist = [
     { name = "ipykernel", specifier = ">6.0.0" },
     { name = "jupytext", specifier = ">=1.14.7" },
     { name = "papermill", specifier = ">=2.4.0" },
-    { name = "pycountry" },
+    { name = "pycountry", specifier = ">=24.6.1" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "seaborn", specifier = ">=0.12.2" },
 ]


### PR DESCRIPTION
## Description
Pin bookshelf for producer.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`

# Notes

I'm not sure yet if this needs to use an identical version of the bookshelf package yet (i.e. are they directly coupled).
