### PR TITLE
Update the pin for pydantic to allow for more recent versions

### DIFF
--- a/changelog/113.trivial.md
+++ b/changelog/113.trivial.md
@@ -1,0 +1,1 @@
+Updated the pin for pydantic to >=1.10.17 which enables some cross-major-version compatibility

--- a/packages/bookshelf/pyproject.toml
+++ b/packages/bookshelf/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "scmdata>=0.16.1",
     "pooch",
-    "pydantic<2",
+    "pydantic>=1.10.17",
     "datapackage>=1.15.2",
     "pyyaml",
     "platformdirs>=4.3.6",

--- a/packages/bookshelf/src/bookshelf/schema.py
+++ b/packages/bookshelf/src/bookshelf/schema.py
@@ -6,7 +6,7 @@ import os
 from typing import Any
 
 import pooch
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from bookshelf.utils import get_env_var, get_notebook_directory
 

--- a/packages/bookshelf/tests/unit/test_schema.py
+++ b/packages/bookshelf/tests/unit/test_schema.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from bookshelf.schema import DatasetMetadata, NotebookMetadata
 from bookshelf.utils import get_notebook_directory

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ requires-dist = [
     { name = "datapackage", specifier = ">=1.15.2" },
     { name = "platformdirs", specifier = ">=4.3.6" },
     { name = "pooch" },
-    { name = "pydantic", specifier = "<2" },
+    { name = "pydantic", specifier = ">=1.10.17" },
     { name = "pyyaml" },
     { name = "scmdata", specifier = ">=0.16.1" },
 ]


### PR DESCRIPTION
## Description

This is blocking the use of the latest pyam-iamc package

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [ ] Documentation added (where applicable)
- [ ] Changelog item added to `changelog/`
