### PR TITLE
fix: report why record mode cannot start

### DIFF
--- a/changelog/137.feature.md
+++ b/changelog/137.feature.md
@@ -1,6 +1,8 @@
 Allow a recorded build to declare `visibility` in its recipe.
 
-It sits alongside the collection, licence and authors,
-and resolves from the caller, then the recipe, then `hidden`.
-This is the same fallback the licence already had,
-so a build file no longer has to hardcode the framing that belongs in `bookshelf.yaml`.
+It sits alongside the collection, licence and authors.
+An omitted `visibility` resolves to the recipe's value, then to `hidden`,
+which is the same fallback the licence already had.
+Only an omitted value falls back,
+so an invalid one is still rejected rather than inheriting the recipe.
+This means a build file no longer has to hardcode the framing that belongs in `bookshelf.yaml`.

--- a/changelog/137.feature.md
+++ b/changelog/137.feature.md
@@ -1,8 +1,5 @@
-Allow a recorded build to declare `visibility` in its recipe.
+Allow a recorded build to declare `visibility` in its recipe, alongside the collection, licence and authors.
 
-It sits alongside the collection, licence and authors.
-An omitted `visibility` resolves to the recipe's value, then to `hidden`,
-which is the same fallback the licence already had.
-Only an omitted value falls back,
-so an invalid one is still rejected rather than inheriting the recipe.
-This means a build file no longer has to hardcode the framing that belongs in `bookshelf.yaml`.
+An omitted `visibility` resolves to the recipe's value, then to `hidden`.
+Only an omitted value falls back, so an invalid one is still rejected.
+A build file no longer has to hardcode the framing that belongs in `bookshelf.yaml`.

--- a/changelog/137.feature.md
+++ b/changelog/137.feature.md
@@ -1,0 +1,6 @@
+Allow a recorded build to declare `visibility` in its recipe.
+
+It sits alongside the collection, licence and authors,
+and resolves from the caller, then the recipe, then `hidden`.
+This is the same fallback the licence already had,
+so a build file no longer has to hardcode the framing that belongs in `bookshelf.yaml`.

--- a/changelog/137.fix.md
+++ b/changelog/137.fix.md
@@ -1,10 +1,11 @@
-Report why record mode cannot start, rather than reporting one ambiguous cause.
+Report which git query failed when record mode cannot start, rather than one ambiguous cause.
 
 - `derive_code_ref` told every failure it was not inside a git repository.
-  Git being unrunnable, the missing `origin` remote, the absent first commit
-  and a repository with no working tree now each name themselves and their own remedy.
-- Every message carries git's own stderr,
-  so a failure for an unrelated reason is not misattributed.
+  It now names the query that failed,
+  offers that query's usual cause as a possibility,
+  and appends git's own stderr.
+  A non-zero exit proves only that the query failed,
+  so a repository whose config git refuses to read is no longer called a missing one.
 - Direct `setup` blamed a missing `collection` argument.
   It now says no recording is active and names both ways forward.
 - An invalid `visibility` in the recipe is reported as a Bookshelf error

--- a/changelog/137.fix.md
+++ b/changelog/137.fix.md
@@ -1,11 +1,15 @@
-Report which git query failed when record mode cannot start, rather than one ambiguous cause.
+Report why record mode cannot start, rather than reporting one ambiguous cause.
 
 - `derive_code_ref` told every failure it was not inside a git repository.
-  It now names the query that failed,
-  offers that query's usual cause as a possibility,
-  and appends git's own stderr.
-  A non-zero exit proves only that the query failed,
-  so a repository whose config git refuses to read is no longer called a missing one.
+  It now names the unmet requirement:
+  git cannot be run,
+  this is not a repository,
+  git refuses to read this repository,
+  the repository is bare,
+  it has no `origin` remote,
+  or it has no commits.
+- Each of those is established rather than inferred from an exit code,
+  because the checks now go through `gitpython`.
 - Direct `setup` blamed a missing `collection` argument.
   It now says no recording is active and names both ways forward.
 - An invalid `visibility` in the recipe is reported as a Bookshelf error

--- a/changelog/137.fix.md
+++ b/changelog/137.fix.md
@@ -1,0 +1,7 @@
+Report why record mode cannot start, rather than reporting one ambiguous cause.
+
+- `derive_code_ref` told every failure it was not inside a git repository.
+  Git being absent, the missing `origin` remote and the absent first commit
+  now each name themselves and their own remedy.
+- Direct `setup` blamed a missing `collection` argument.
+  It now says no recording is active and names both ways forward.

--- a/changelog/137.fix.md
+++ b/changelog/137.fix.md
@@ -1,16 +1,8 @@
 Report why record mode cannot start, rather than reporting one ambiguous cause.
 
 - `derive_code_ref` told every failure it was not inside a git repository.
-  It now names the unmet requirement:
-  git cannot be run,
-  this is not a repository,
-  git refuses to read this repository,
-  the repository is bare,
-  it has no `origin` remote,
-  or it has no commits.
-- Each of those is established rather than inferred from an exit code,
-  because the checks now go through `gitpython`.
+  It now names the unmet requirement: git cannot be run, this is not a repository,
+  git refuses to read it, it is bare, it has no `origin` remote, or it has no commits.
 - Direct `setup` blamed a missing `collection` argument.
   It now says no recording is active and names both ways forward.
-- An invalid `visibility` in the recipe is reported as a Bookshelf error
-  rather than escaping as a `TypeError`.
+- An invalid `visibility` in the recipe is reported as a Bookshelf error rather than a `TypeError`.

--- a/changelog/137.fix.md
+++ b/changelog/137.fix.md
@@ -1,7 +1,11 @@
 Report why record mode cannot start, rather than reporting one ambiguous cause.
 
 - `derive_code_ref` told every failure it was not inside a git repository.
-  Git being absent, the missing `origin` remote and the absent first commit
-  now each name themselves and their own remedy.
+  Git being unrunnable, the missing `origin` remote, the absent first commit
+  and a repository with no working tree now each name themselves and their own remedy.
+- Every message carries git's own stderr,
+  so a failure for an unrelated reason is not misattributed.
 - Direct `setup` blamed a missing `collection` argument.
   It now says no recording is active and names both ways forward.
+- An invalid `visibility` in the recipe is reported as a Bookshelf error
+  rather than escaping as a `TypeError`.

--- a/changelog/137.improvement.md
+++ b/changelog/137.improvement.md
@@ -1,0 +1,6 @@
+Read git provenance through `gitpython` rather than parsing `git` output.
+
+`gitpython` is imported lazily inside the provenance helper,
+because it raises at import time when no git binary is present
+and consuming a book never needs git.
+Importing `bookshelf` therefore still works without git installed.

--- a/changelog/137.improvement.md
+++ b/changelog/137.improvement.md
@@ -1,6 +1,1 @@
 Read git provenance through `gitpython` rather than parsing `git` output.
-
-`gitpython` is imported lazily inside the provenance helper,
-because it raises at import time when no git binary is present
-and consuming a book never needs git.
-Importing `bookshelf` therefore still works without git installed.

--- a/packages/bookshelf/pyproject.toml
+++ b/packages/bookshelf/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
+    "gitpython>=3.1",
     "httpx>=0.27",
     "keyring>=25",
     "pydantic>=2.7",

--- a/packages/bookshelf/src/bookshelf/_produce/provenance.py
+++ b/packages/bookshelf/src/bookshelf/_produce/provenance.py
@@ -12,16 +12,8 @@ from bookshelf._core.hashing import canonical_json_bytes, sha256_hex
 def derive_code_ref() -> str:
     """Return ``<remote-url>@<sha>[+dirty]`` for the current git checkout.
 
-    Raises :class:`~bookshelf._core.errors.BookshelfError`
-    naming the unmet requirement:
-    git cannot be run,
-    this is not a repository,
-    git refuses to read this repository,
-    the repository is bare,
-    it has no ``origin`` remote,
-    or it has no commits.
-    Each of those is established rather than guessed,
-    so the message states it as fact.
+    Raises :class:`~bookshelf._core.errors.BookshelfError` naming the unmet requirement,
+    whether git cannot be run, this is not a usable repository, or it has no commits.
     The caller may pass ``code_ref=`` explicitly instead.
     """
     # gitpython raises at import time when the git binary is absent, and consuming a
@@ -61,8 +53,7 @@ def _derive_code_ref() -> str:
             "Run from a clone, or pass code_ref= explicitly."
         ) from exc
 
-    # gitpython reads refs and config in pure Python, which skips the validation git
-    # itself applies, so a repository git rejects would otherwise read as an empty one.
+    # gitpython reads refs and config in pure Python, so a repository git itself rejects reads as empty.
     # Running a real git command first makes that failure surface as itself.
     try:
         dirty = repo.is_dirty(untracked_files=True)

--- a/packages/bookshelf/src/bookshelf/_produce/provenance.py
+++ b/packages/bookshelf/src/bookshelf/_produce/provenance.py
@@ -44,12 +44,20 @@ def derive_code_ref() -> str:
     so each is reported separately and carries git's own stderr.
     The caller may pass ``code_ref=`` explicitly instead.
     """
+    # Every command shares one exec-layer diagnosis, because a git that cannot run
+    # says nothing about which query was in flight.
     try:
-        _git("rev-parse", "--git-dir")
+        return _derive_code_ref()
     except OSError as exc:
         raise BookshelfError(
             f"Cannot derive code_ref: git could not be run ({exc}). Pass code_ref= explicitly."
         ) from exc
+
+
+def _derive_code_ref() -> str:
+    """Query git for the code ref, mapping each command's own failure to its cause."""
+    try:
+        _git("rev-parse", "--git-dir")
     except subprocess.CalledProcessError as exc:
         raise BookshelfError(
             "Cannot derive code_ref: not inside a git repository. "

--- a/packages/bookshelf/src/bookshelf/_produce/provenance.py
+++ b/packages/bookshelf/src/bookshelf/_produce/provenance.py
@@ -9,44 +9,62 @@ from bookshelf._core.errors import BookshelfError
 from bookshelf._core.hashing import canonical_json_bytes, sha256_hex
 
 
+def _git(*args: str) -> str:
+    """Return the stripped stdout of one git command."""
+    return subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
 def derive_code_ref() -> str:
     """Return ``<remote-url>@<sha>[+dirty]`` for the current git checkout.
 
     Raises :class:`~bookshelf._core.errors.BookshelfError`
-    when the working directory is not inside a git repository
-    or when git is unavailable.
-    The caller must pass ``code_ref=`` explicitly in that case.
+    naming which requirement is unmet:
+    git is unavailable,
+    this is not a repository,
+    there is no ``origin`` remote,
+    or there is no commit to record.
+    Each of those needs a different fix,
+    so they are reported separately rather than as one ambiguous message.
+    The caller may pass ``code_ref=`` explicitly instead.
     """
     try:
-        remote = subprocess.run(
-            ["git", "remote", "get-url", "origin"],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-        sha = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-        dirty = (
-            subprocess.run(
-                ["git", "status", "--porcelain"],
-                capture_output=True,
-                text=True,
-                check=True,
-            ).stdout.strip()
-            != ""
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        _git("rev-parse", "--git-dir")
+    except FileNotFoundError as exc:
         raise BookshelfError(
-            "Cannot derive code_ref: not inside a git repository "
-            "(or git is not available). Pass code_ref= explicitly."
+            "Cannot derive code_ref: git is not installed or not on PATH. "
+            "Pass code_ref= explicitly."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise BookshelfError(
+            "Cannot derive code_ref: not inside a git repository. "
+            "Run from a clone, or pass code_ref= explicitly."
+        ) from exc
+
+    try:
+        remote = _git("remote", "get-url", "origin")
+    except subprocess.CalledProcessError as exc:
+        raise BookshelfError(
+            "Cannot derive code_ref: this repository has no 'origin' remote, "
+            "so the code has no address to record. "
+            "Add one with 'git remote add origin <url>', or pass code_ref= explicitly."
+        ) from exc
+
+    try:
+        sha = _git("rev-parse", "HEAD")
+    except subprocess.CalledProcessError as exc:
+        raise BookshelfError(
+            "Cannot derive code_ref: this repository has no commits, "
+            "so there is no revision to record. "
+            "Commit first, or pass code_ref= explicitly."
         ) from exc
 
     ref = f"{remote}@{sha}"
-    if dirty:
+    if _git("status", "--porcelain"):
         ref += "+dirty"
     return ref
 

--- a/packages/bookshelf/src/bookshelf/_produce/provenance.py
+++ b/packages/bookshelf/src/bookshelf/_produce/provenance.py
@@ -27,7 +27,8 @@ def derive_code_ref() -> str:
     git is unavailable,
     this is not a repository,
     there is no ``origin`` remote,
-    or there is no commit to record.
+    there is no commit to record,
+    or there is no working tree to read state from.
     Each of those needs a different fix,
     so they are reported separately rather than as one ambiguous message.
     The caller may pass ``code_ref=`` explicitly instead.
@@ -63,8 +64,17 @@ def derive_code_ref() -> str:
             "Commit first, or pass code_ref= explicitly."
         ) from exc
 
+    try:
+        dirty = _git("status", "--porcelain")
+    except subprocess.CalledProcessError as exc:
+        raise BookshelfError(
+            "Cannot derive code_ref: this repository has no working tree, "
+            "so its state cannot be read. "
+            "Run from a normal clone, or pass code_ref= explicitly."
+        ) from exc
+
     ref = f"{remote}@{sha}"
-    if _git("status", "--porcelain"):
+    if dirty:
         ref += "+dirty"
     return ref
 

--- a/packages/bookshelf/src/bookshelf/_produce/provenance.py
+++ b/packages/bookshelf/src/bookshelf/_produce/provenance.py
@@ -20,11 +20,12 @@ def _git(*args: str) -> str:
 
 
 def _said(exc: subprocess.CalledProcessError) -> str:
-    """Return git's own stderr, so a diagnosis is never more confident than the evidence.
+    """Return git's own stderr as supplemental detail, empty when git emitted none.
 
-    A command fails for reasons other than the one being tested,
-    such as dubious ownership under ``safe.directory`` or a held ``index.lock``,
-    and the caller needs to see that rather than an authoritative guess.
+    A non-zero exit proves only that the query failed,
+    never why it failed,
+    so callers name the query and offer its usual cause as a possibility.
+    The specifics come from here.
     """
     detail = str(exc.stderr or "").strip()
     return f" git said: {detail}" if detail else ""
@@ -34,14 +35,18 @@ def derive_code_ref() -> str:
     """Return ``<remote-url>@<sha>[+dirty]`` for the current git checkout.
 
     Raises :class:`~bookshelf._core.errors.BookshelfError`
-    naming which requirement is unmet:
-    git is unavailable,
-    this is not a repository,
-    there is no ``origin`` remote,
-    there is no commit to record,
-    or there is no working tree to read state from.
-    Each of those needs a different fix,
-    so each is reported separately and carries git's own stderr.
+    naming the query that failed:
+    git could not be run,
+    no repository could be identified,
+    no ``origin`` remote could be read,
+    ``HEAD`` could not be resolved,
+    or the working tree state could not be read.
+    Each query has a different usual cause and a different fix,
+    so each is reported separately with its cause offered as a possibility.
+    A repository whose config git refuses to read fails the first query
+    without being the usual cause of that failure,
+    which is why none of these is stated as established fact.
+    Git's own stderr is appended whenever git ran and produced any.
     The caller may pass ``code_ref=`` explicitly instead.
     """
     # Every command shares one exec-layer diagnosis, because a git that cannot run
@@ -55,21 +60,22 @@ def derive_code_ref() -> str:
 
 
 def _derive_code_ref() -> str:
-    """Query git for the code ref, mapping each command's own failure to its cause."""
+    """Query git for the code ref, naming whichever query fails."""
     try:
         _git("rev-parse", "--git-dir")
     except subprocess.CalledProcessError as exc:
         raise BookshelfError(
-            "Cannot derive code_ref: not inside a git repository. "
-            f"Run from a clone, or pass code_ref= explicitly.{_said(exc)}"
+            "Cannot derive code_ref: git could not identify a repository here, "
+            "usually because this is not a clone. "
+            f"Run from one, or pass code_ref= explicitly.{_said(exc)}"
         ) from exc
 
     try:
         remote = _git("remote", "get-url", "origin")
     except subprocess.CalledProcessError as exc:
         raise BookshelfError(
-            "Cannot derive code_ref: this repository has no 'origin' remote, "
-            "so the code has no address to record. "
+            "Cannot derive code_ref: git could not read an 'origin' remote, "
+            "usually because none is set, so the code has no address to record. "
             f"Add one with 'git remote add origin <url>', or pass code_ref= explicitly.{_said(exc)}"
         ) from exc
 
@@ -77,17 +83,17 @@ def _derive_code_ref() -> str:
         sha = _git("rev-parse", "HEAD")
     except subprocess.CalledProcessError as exc:
         raise BookshelfError(
-            "Cannot derive code_ref: this repository has no commits, "
-            "so there is no revision to record. "
-            f"Commit first, or pass code_ref= explicitly.{_said(exc)}"
+            "Cannot derive code_ref: git could not resolve HEAD, "
+            "usually because the repository has no commits, "
+            f"so there is no revision to record. Commit first, or pass code_ref= explicitly.{_said(exc)}"
         ) from exc
 
     try:
         dirty = _git("status", "--porcelain")
     except subprocess.CalledProcessError as exc:
         raise BookshelfError(
-            "Cannot derive code_ref: this repository has no working tree, "
-            "so its state cannot be read. "
+            "Cannot derive code_ref: git could not read the working tree state, "
+            "usually because the repository is bare. "
             f"Run from a normal clone, or pass code_ref= explicitly.{_said(exc)}"
         ) from exc
 

--- a/packages/bookshelf/src/bookshelf/_produce/provenance.py
+++ b/packages/bookshelf/src/bookshelf/_produce/provenance.py
@@ -19,6 +19,17 @@ def _git(*args: str) -> str:
     ).stdout.strip()
 
 
+def _said(exc: subprocess.CalledProcessError) -> str:
+    """Return git's own stderr, so a diagnosis is never more confident than the evidence.
+
+    A command fails for reasons other than the one being tested,
+    such as dubious ownership under ``safe.directory`` or a held ``index.lock``,
+    and the caller needs to see that rather than an authoritative guess.
+    """
+    detail = str(exc.stderr or "").strip()
+    return f" git said: {detail}" if detail else ""
+
+
 def derive_code_ref() -> str:
     """Return ``<remote-url>@<sha>[+dirty]`` for the current git checkout.
 
@@ -30,20 +41,19 @@ def derive_code_ref() -> str:
     there is no commit to record,
     or there is no working tree to read state from.
     Each of those needs a different fix,
-    so they are reported separately rather than as one ambiguous message.
+    so each is reported separately and carries git's own stderr.
     The caller may pass ``code_ref=`` explicitly instead.
     """
     try:
         _git("rev-parse", "--git-dir")
-    except FileNotFoundError as exc:
+    except OSError as exc:
         raise BookshelfError(
-            "Cannot derive code_ref: git is not installed or not on PATH. "
-            "Pass code_ref= explicitly."
+            f"Cannot derive code_ref: git could not be run ({exc}). Pass code_ref= explicitly."
         ) from exc
     except subprocess.CalledProcessError as exc:
         raise BookshelfError(
             "Cannot derive code_ref: not inside a git repository. "
-            "Run from a clone, or pass code_ref= explicitly."
+            f"Run from a clone, or pass code_ref= explicitly.{_said(exc)}"
         ) from exc
 
     try:
@@ -52,7 +62,7 @@ def derive_code_ref() -> str:
         raise BookshelfError(
             "Cannot derive code_ref: this repository has no 'origin' remote, "
             "so the code has no address to record. "
-            "Add one with 'git remote add origin <url>', or pass code_ref= explicitly."
+            f"Add one with 'git remote add origin <url>', or pass code_ref= explicitly.{_said(exc)}"
         ) from exc
 
     try:
@@ -61,7 +71,7 @@ def derive_code_ref() -> str:
         raise BookshelfError(
             "Cannot derive code_ref: this repository has no commits, "
             "so there is no revision to record. "
-            "Commit first, or pass code_ref= explicitly."
+            f"Commit first, or pass code_ref= explicitly.{_said(exc)}"
         ) from exc
 
     try:
@@ -70,7 +80,7 @@ def derive_code_ref() -> str:
         raise BookshelfError(
             "Cannot derive code_ref: this repository has no working tree, "
             "so its state cannot be read. "
-            "Run from a normal clone, or pass code_ref= explicitly."
+            f"Run from a normal clone, or pass code_ref= explicitly.{_said(exc)}"
         ) from exc
 
     ref = f"{remote}@{sha}"

--- a/packages/bookshelf/src/bookshelf/_produce/provenance.py
+++ b/packages/bookshelf/src/bookshelf/_produce/provenance.py
@@ -73,9 +73,10 @@ def _derive_code_ref() -> str:
         ) from exc
     except git.GitCommandError as exc:
         detail = str(exc.stderr or "").strip()
+        said = f" git said: {detail}" if detail else ""
         raise BookshelfError(
             "Cannot derive code_ref: git refused to read this repository. "
-            f"Pass code_ref= explicitly. git said: {detail}"
+            f"Pass code_ref= explicitly.{said}"
         ) from exc
 
     if repo.bare:

--- a/packages/bookshelf/src/bookshelf/_produce/provenance.py
+++ b/packages/bookshelf/src/bookshelf/_produce/provenance.py
@@ -2,102 +2,102 @@
 
 from __future__ import annotations
 
-import subprocess
+from pathlib import Path
 from typing import Any
 
 from bookshelf._core.errors import BookshelfError
 from bookshelf._core.hashing import canonical_json_bytes, sha256_hex
 
 
-def _git(*args: str) -> str:
-    """Return the stripped stdout of one git command."""
-    return subprocess.run(
-        ["git", *args],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout.strip()
-
-
-def _said(exc: subprocess.CalledProcessError) -> str:
-    """Return git's own stderr as supplemental detail, empty when git emitted none.
-
-    A non-zero exit proves only that the query failed,
-    never why it failed,
-    so callers name the query and offer its usual cause as a possibility.
-    The specifics come from here.
-    """
-    detail = str(exc.stderr or "").strip()
-    return f" git said: {detail}" if detail else ""
-
-
 def derive_code_ref() -> str:
     """Return ``<remote-url>@<sha>[+dirty]`` for the current git checkout.
 
     Raises :class:`~bookshelf._core.errors.BookshelfError`
-    naming the query that failed:
-    git could not be run,
-    no repository could be identified,
-    no ``origin`` remote could be read,
-    ``HEAD`` could not be resolved,
-    or the working tree state could not be read.
-    Each query has a different usual cause and a different fix,
-    so each is reported separately with its cause offered as a possibility.
-    A repository whose config git refuses to read fails the first query
-    without being the usual cause of that failure,
-    which is why none of these is stated as established fact.
-    Git's own stderr is appended whenever git ran and produced any.
+    naming the unmet requirement:
+    git cannot be run,
+    this is not a repository,
+    git refuses to read this repository,
+    the repository is bare,
+    it has no ``origin`` remote,
+    or it has no commits.
+    Each of those is established rather than guessed,
+    so the message states it as fact.
     The caller may pass ``code_ref=`` explicitly instead.
     """
-    # Every command shares one exec-layer diagnosis, because a git that cannot run
-    # says nothing about which query was in flight.
+    # gitpython raises at import time when the git binary is absent, and consuming a
+    # book never needs git, so importing bookshelf must not depend on it.
+    try:
+        import git
+    except ImportError as exc:
+        raise BookshelfError(
+            "Cannot derive code_ref: git could not be run, "
+            "because it is not installed or not on PATH. "
+            "Pass code_ref= explicitly."
+        ) from exc
+
+    # Backstop, so nothing gitpython raises escapes as anything but a BookshelfError.
     try:
         return _derive_code_ref()
-    except OSError as exc:
+    except (git.GitError, OSError) as exc:
         raise BookshelfError(
-            f"Cannot derive code_ref: git could not be run ({exc}). Pass code_ref= explicitly."
+            f"Cannot derive code_ref: git could not be queried ({exc}). Pass code_ref= explicitly."
         ) from exc
 
 
 def _derive_code_ref() -> str:
-    """Query git for the code ref, naming whichever query fails."""
-    try:
-        _git("rev-parse", "--git-dir")
-    except subprocess.CalledProcessError as exc:
-        raise BookshelfError(
-            "Cannot derive code_ref: git could not identify a repository here, "
-            "usually because this is not a clone. "
-            f"Run from one, or pass code_ref= explicitly.{_said(exc)}"
-        ) from exc
+    """Read the code ref from the repository containing the working directory."""
+    import git
 
     try:
-        remote = _git("remote", "get-url", "origin")
-    except subprocess.CalledProcessError as exc:
+        repo = git.Repo(Path.cwd(), search_parent_directories=True)
+    except git.NoSuchPathError as exc:
         raise BookshelfError(
-            "Cannot derive code_ref: git could not read an 'origin' remote, "
-            "usually because none is set, so the code has no address to record. "
-            f"Add one with 'git remote add origin <url>', or pass code_ref= explicitly.{_said(exc)}"
+            "Cannot derive code_ref: the working directory no longer exists. "
+            "Pass code_ref= explicitly."
+        ) from exc
+    except git.InvalidGitRepositoryError as exc:
+        raise BookshelfError(
+            "Cannot derive code_ref: not inside a git repository. "
+            "Run from a clone, or pass code_ref= explicitly."
         ) from exc
 
+    # gitpython reads refs and config in pure Python, which skips the validation git
+    # itself applies, so a repository git rejects would otherwise read as an empty one.
+    # Running a real git command first makes that failure surface as itself.
     try:
-        sha = _git("rev-parse", "HEAD")
-    except subprocess.CalledProcessError as exc:
+        dirty = repo.is_dirty(untracked_files=True)
+    except (git.GitCommandNotFound, OSError) as exc:
+        # A git that is absent, or present but not executable, lands here.
         raise BookshelfError(
-            "Cannot derive code_ref: git could not resolve HEAD, "
-            "usually because the repository has no commits, "
-            f"so there is no revision to record. Commit first, or pass code_ref= explicitly.{_said(exc)}"
+            f"Cannot derive code_ref: git could not be run ({exc}). Pass code_ref= explicitly."
+        ) from exc
+    except git.GitCommandError as exc:
+        detail = str(exc.stderr or "").strip()
+        raise BookshelfError(
+            "Cannot derive code_ref: git refused to read this repository. "
+            f"Pass code_ref= explicitly. git said: {detail}"
         ) from exc
 
-    try:
-        dirty = _git("status", "--porcelain")
-    except subprocess.CalledProcessError as exc:
+    if repo.bare:
         raise BookshelfError(
-            "Cannot derive code_ref: git could not read the working tree state, "
-            "usually because the repository is bare. "
-            f"Run from a normal clone, or pass code_ref= explicitly.{_said(exc)}"
-        ) from exc
+            "Cannot derive code_ref: this repository is bare, so it has no working tree "
+            "whose state can be recorded. "
+            "Run from a normal clone, or pass code_ref= explicitly."
+        )
+    if "origin" not in {remote.name for remote in repo.remotes}:
+        raise BookshelfError(
+            "Cannot derive code_ref: this repository has no 'origin' remote, "
+            "so the code has no address to record. "
+            "Add one with 'git remote add origin <url>', or pass code_ref= explicitly."
+        )
+    if not repo.head.is_valid():
+        raise BookshelfError(
+            "Cannot derive code_ref: this repository has no commits, "
+            "so there is no revision to record. "
+            "Commit first, or pass code_ref= explicitly."
+        )
 
-    ref = f"{remote}@{sha}"
+    ref = f"{repo.remotes.origin.url}@{repo.head.commit.hexsha}"
     if dirty:
         ref += "+dirty"
     return ref

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -48,6 +48,7 @@ class RecordRecipe:
     license: str
     authors: tuple[dict[str, Any], ...]
     notebook: Path | None = None
+    visibility: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -644,13 +645,20 @@ class SetupResult:
 def setup(
     *,
     version: str,
-    visibility: str | models.Visibility = models.Visibility.hidden,
+    visibility: str | models.Visibility | None = None,
     license: str | None = None,
     collection: str | None = None,
     base_url: str | None = None,
     auth: AuthInput = UNSET,
 ) -> SetupResult:
-    """Construct live or recording handles for a standalone build file."""
+    """Construct live or recording handles for a standalone build file.
+
+    ``visibility`` and ``license`` fall back to the recipe when omitted,
+    so a recorded build declares its framing in ``bookshelf.yaml``
+    rather than repeating it here.
+    Both default to the recipe's value,
+    then to :attr:`~bookshelf.models.Visibility.hidden` for visibility.
+    """
     book: DraftBook | RecordedDraftBook
     context = _ACTIVE_RECORDING.get()
     if context is not None:
@@ -670,7 +678,7 @@ def setup(
         book = context.bookshelf.draft_book(
             collection or context.recipe.collection,
             version=version,
-            visibility=visibility,
+            visibility=visibility or context.recipe.visibility or models.Visibility.hidden,
             license=license or context.recipe.license,
         )
         if not isinstance(book, RecordedDraftBook):
@@ -679,12 +687,17 @@ def setup(
         context.setup_called = True
         return SetupResult(context.bookshelf, book)
     if collection is None:
-        raise BookshelfError("direct setup requires collection")
+        raise BookshelfError(
+            "bookshelf.setup found no active recording, and no collection was passed. "
+            "A build file is executed by the recorder, which reads the collection from "
+            "the recipe, so run it with bookshelf.publisher.run_record. "
+            "Pass collection= to build against the API directly instead."
+        )
     bs = Bookshelf(base_url, auth=auth)
     book = bs.draft_book(
         collection,
         version=version,
-        visibility=visibility,
+        visibility=visibility or models.Visibility.hidden,
         license=license,
     )
     return SetupResult(bs, book)
@@ -708,11 +721,16 @@ def load_record_recipe(path: Path) -> RecordRecipe:
         raise BookshelfError(f"{path} authors must be a list of mappings")
     notebook_raw = raw.get("notebook")
     notebook = Path(notebook_raw) if isinstance(notebook_raw, str) else None
+    visibility_raw = raw.get("visibility")
+    if visibility_raw is not None and visibility_raw not in set(models.Visibility):
+        allowed = ", ".join(sorted(models.Visibility))
+        raise BookshelfError(f"{path} visibility must be one of {allowed}, got {visibility_raw!r}")
     return RecordRecipe(
         collection=collection,
         license=license_value,
         authors=tuple(dict(author) for author in authors_raw),
         notebook=notebook,
+        visibility=visibility_raw,
     )
 
 

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -682,7 +682,13 @@ def setup(
         book = context.bookshelf.draft_book(
             collection or context.recipe.collection,
             version=version,
-            visibility=visibility or context.recipe.visibility or models.Visibility.hidden,
+            # `is not None`, not `or`: an explicit empty string is invalid input to
+            # reject, never a signal to inherit whatever the recipe declares.
+            visibility=(
+                visibility
+                if visibility is not None
+                else context.recipe.visibility or models.Visibility.hidden
+            ),
             license=license or context.recipe.license,
         )
         if not isinstance(book, RecordedDraftBook):
@@ -701,7 +707,7 @@ def setup(
     book = bs.draft_book(
         collection,
         version=version,
-        visibility=visibility or models.Visibility.hidden,
+        visibility=visibility if visibility is not None else models.Visibility.hidden,
         license=license,
     )
     return SetupResult(bs, book)

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -726,7 +726,9 @@ def load_record_recipe(path: Path) -> RecordRecipe:
     notebook_raw = raw.get("notebook")
     notebook = Path(notebook_raw) if isinstance(notebook_raw, str) else None
     visibility_raw = raw.get("visibility")
-    if visibility_raw is not None and visibility_raw not in set(models.Visibility):
+    if visibility_raw is not None and (
+        not isinstance(visibility_raw, str) or visibility_raw not in set(models.Visibility)
+    ):
         allowed = ", ".join(sorted(models.Visibility))
         raise BookshelfError(f"{path} visibility must be one of {allowed}, got {visibility_raw!r}")
     return RecordRecipe(

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -653,15 +653,11 @@ def setup(
 ) -> SetupResult:
     """Construct live or recording handles for a standalone build file.
 
-    Under an active recording,
-    ``visibility`` and ``license`` fall back to the recipe when omitted,
-    so a recorded build declares its framing in ``bookshelf.yaml``
-    rather than repeating it in the build file.
-    Visibility resolves from the caller,
-    then the recipe,
+    Under an active recording, ``visibility`` and ``license`` fall back to the recipe when omitted,
+    so a recorded build declares its framing in ``bookshelf.yaml`` rather than in the build file.
+    Visibility resolves from the caller, then the recipe,
     then :attr:`~bookshelf.models.Visibility.hidden`.
-    Direct use has no recipe to consult,
-    so an omitted visibility is ``hidden`` and an omitted licence stays unset.
+    Direct use has no recipe, so an omitted visibility is ``hidden`` and an omitted licence stays unset.
     """
     book: DraftBook | RecordedDraftBook
     context = _ACTIVE_RECORDING.get()
@@ -682,8 +678,8 @@ def setup(
         book = context.bookshelf.draft_book(
             collection or context.recipe.collection,
             version=version,
-            # `is not None`, not `or`: an explicit empty string is invalid input to
-            # reject, never a signal to inherit whatever the recipe declares.
+            # `is not None`, not `or`: an empty string is invalid input to reject,
+            # never a signal to inherit the recipe's value.
             visibility=(
                 visibility
                 if visibility is not None

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -653,11 +653,15 @@ def setup(
 ) -> SetupResult:
     """Construct live or recording handles for a standalone build file.
 
+    Under an active recording,
     ``visibility`` and ``license`` fall back to the recipe when omitted,
     so a recorded build declares its framing in ``bookshelf.yaml``
-    rather than repeating it here.
-    Both default to the recipe's value,
-    then to :attr:`~bookshelf.models.Visibility.hidden` for visibility.
+    rather than repeating it in the build file.
+    Visibility resolves from the caller,
+    then the recipe,
+    then :attr:`~bookshelf.models.Visibility.hidden`.
+    Direct use has no recipe to consult,
+    so an omitted visibility is ``hidden`` and an omitted licence stays unset.
     """
     book: DraftBook | RecordedDraftBook
     context = _ACTIVE_RECORDING.get()

--- a/packages/bookshelf/tests/test_packaging.py
+++ b/packages/bookshelf/tests/test_packaging.py
@@ -1,5 +1,8 @@
 """Packaging tests for the single-namespace SDK wheel."""
 
+import os
+import subprocess
+import sys
 import tomllib
 from email.parser import Parser
 from pathlib import Path
@@ -74,3 +77,21 @@ def test_wheel_declares_one_package_with_the_generated_core(wheel: Path) -> None
     }
     assert required <= names
     assert not any(name.startswith("bookshelf_client/") for name in names)
+
+
+def test_importing_the_sdk_does_not_require_the_git_binary() -> None:
+    """Consuming a book never needs git, so the import must not depend on it.
+
+    gitpython raises at import time when no git binary is found,
+    which is why the provenance helper imports it lazily.
+    A subprocess is required because gitpython is already imported in this one.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", "import bookshelf"],
+        env={**os.environ, "PATH": ""},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/packages/bookshelf/tests/test_provenance.py
+++ b/packages/bookshelf/tests/test_provenance.py
@@ -74,13 +74,36 @@ def test_an_uncommitted_change_marks_the_ref_dirty(
     assert derive_code_ref().endswith("+dirty")
 
 
-def test_a_missing_git_binary_is_reported_as_such(
+def test_an_unrunnable_git_is_reported_as_such(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("PATH", "")
 
-    with pytest.raises(BookshelfError, match="git is not installed"):
+    with pytest.raises(BookshelfError, match="git could not be run"):
+        derive_code_ref()
+
+
+def test_a_git_that_cannot_be_executed_stays_on_the_bookshelf_error_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A present but non-executable git raises PermissionError, not FileNotFoundError."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "git").write_text("#!/bin/sh\nexit 0\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PATH", str(fake_bin))
+
+    with pytest.raises(BookshelfError, match="git could not be run"):
+        derive_code_ref()
+
+
+def test_a_failure_carries_gits_own_stderr(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The diagnosis must not sound more certain than the evidence behind it."""
+    monkeypatch.setenv("GIT_CEILING_DIRECTORIES", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(BookshelfError, match="git said:"):
         derive_code_ref()
 
 

--- a/packages/bookshelf/tests/test_provenance.py
+++ b/packages/bookshelf/tests/test_provenance.py
@@ -98,6 +98,29 @@ def test_a_git_that_cannot_be_executed_stays_on_the_bookshelf_error_path(
         derive_code_ref()
 
 
+def test_an_exec_failure_after_the_first_command_is_still_a_bookshelf_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only the first command used to be guarded, so later exec failures escaped raw."""
+    _git(tmp_path, "init")
+    _git(tmp_path, "remote", "add", "origin", "https://example.com/thing")
+    monkeypatch.chdir(tmp_path)
+
+    real_run = subprocess.run
+    calls = {"n": 0}
+
+    def _fail_after_the_first(*args: object, **kwargs: object) -> object:
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise OSError(24, "Too many open files")
+        return real_run(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(subprocess, "run", _fail_after_the_first)
+
+    with pytest.raises(BookshelfError, match="git could not be run"):
+        derive_code_ref()
+
+
 def test_a_failure_carries_gits_own_stderr(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The diagnosis must not sound more certain than the evidence behind it."""
     monkeypatch.setenv("GIT_CEILING_DIRECTORIES", str(tmp_path))

--- a/packages/bookshelf/tests/test_provenance.py
+++ b/packages/bookshelf/tests/test_provenance.py
@@ -1,8 +1,13 @@
-"""Tests for bookshelf._produce.provenance: git-derived activity provenance."""
+"""Tests for bookshelf._produce.provenance: git-derived activity provenance.
+
+Record mode catches :class:`BookshelfError`,
+so the contract these tests defend is that nothing else escapes ``derive_code_ref``.
+"""
 
 import subprocess
 from pathlib import Path
 
+import git
 import pytest
 
 from bookshelf._core.errors import BookshelfError
@@ -14,12 +19,19 @@ def _git(cwd: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
 
 
+def _repo_with_a_commit(path: Path) -> None:
+    """Build a repository carrying an origin and one commit."""
+    _git(path, "init")
+    _git(path, "remote", "add", "origin", "https://example.com/thing")
+    (path / "a.txt").write_text("a")
+    _git(path, "add", "a.txt")
+    _git(path, "-c", "user.name=T", "-c", "user.email=t@example.com", "commit", "-m", "one")
+
+
 def test_outside_a_repository_says_so(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # The ceiling stops git walking up, so the result does not depend on where TMPDIR sits.
-    monkeypatch.setenv("GIT_CEILING_DIRECTORIES", str(tmp_path))
     monkeypatch.chdir(tmp_path)
 
-    with pytest.raises(BookshelfError, match="could not identify a repository"):
+    with pytest.raises(BookshelfError, match="not inside a git repository"):
         derive_code_ref()
 
 
@@ -29,7 +41,7 @@ def test_a_missing_origin_remote_names_the_remote(
     _git(tmp_path, "init")
     monkeypatch.chdir(tmp_path)
 
-    with pytest.raises(BookshelfError, match="could not read an 'origin' remote"):
+    with pytest.raises(BookshelfError, match="no 'origin' remote"):
         derive_code_ref()
 
 
@@ -40,18 +52,14 @@ def test_a_repository_with_no_commits_names_the_commit(
     _git(tmp_path, "remote", "add", "origin", "https://example.com/thing")
     monkeypatch.chdir(tmp_path)
 
-    with pytest.raises(BookshelfError, match="could not resolve HEAD"):
+    with pytest.raises(BookshelfError, match="no commits"):
         derive_code_ref()
 
 
 def test_a_clean_checkout_derives_remote_and_sha(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _git(tmp_path, "init")
-    _git(tmp_path, "remote", "add", "origin", "https://example.com/thing")
-    (tmp_path / "a.txt").write_text("a")
-    _git(tmp_path, "add", "a.txt")
-    _git(tmp_path, "-c", "user.name=T", "-c", "user.email=t@example.com", "commit", "-m", "one")
+    _repo_with_a_commit(tmp_path)
     monkeypatch.chdir(tmp_path)
 
     ref = derive_code_ref()
@@ -63,20 +71,28 @@ def test_a_clean_checkout_derives_remote_and_sha(
 def test_an_uncommitted_change_marks_the_ref_dirty(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _git(tmp_path, "init")
-    _git(tmp_path, "remote", "add", "origin", "https://example.com/thing")
-    (tmp_path / "a.txt").write_text("a")
-    _git(tmp_path, "add", "a.txt")
-    _git(tmp_path, "-c", "user.name=T", "-c", "user.email=t@example.com", "commit", "-m", "one")
+    _repo_with_a_commit(tmp_path)
     (tmp_path / "a.txt").write_text("changed")
     monkeypatch.chdir(tmp_path)
 
     assert derive_code_ref().endswith("+dirty")
 
 
-def test_an_unrunnable_git_is_reported_as_such(
+def test_an_untracked_file_marks_the_ref_dirty(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """An unadded build output is a difference between the code and the recorded ref."""
+    _repo_with_a_commit(tmp_path)
+    (tmp_path / "new.txt").write_text("new")
+    monkeypatch.chdir(tmp_path)
+
+    assert derive_code_ref().endswith("+dirty")
+
+
+def test_a_missing_git_binary_is_reported_as_unrunnable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _repo_with_a_commit(tmp_path)
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("PATH", "")
 
@@ -84,10 +100,11 @@ def test_an_unrunnable_git_is_reported_as_such(
         derive_code_ref()
 
 
-def test_a_git_that_cannot_be_executed_stays_on_the_bookshelf_error_path(
+def test_a_git_that_cannot_be_executed_is_reported_as_unrunnable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A present but non-executable git raises PermissionError, not FileNotFoundError."""
+    """A present but non-executable git raises PermissionError, not a gitpython error."""
+    _repo_with_a_commit(tmp_path)
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     (fake_bin / "git").write_text("#!/bin/sh\nexit 0\n")
@@ -98,44 +115,29 @@ def test_a_git_that_cannot_be_executed_stays_on_the_bookshelf_error_path(
         derive_code_ref()
 
 
-def test_an_exec_failure_after_the_first_command_is_still_a_bookshelf_error(
+def test_an_unmapped_gitpython_error_still_becomes_a_bookshelf_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Only the first command used to be guarded, so later exec failures escaped raw."""
-    _git(tmp_path, "init")
-    _git(tmp_path, "remote", "add", "origin", "https://example.com/thing")
+    """The backstop exists so a gitpython error nobody anticipated cannot escape raw."""
+    _repo_with_a_commit(tmp_path)
     monkeypatch.chdir(tmp_path)
 
-    real_run = subprocess.run
-    calls = {"n": 0}
+    def _boom(*args: object, **kwargs: object) -> bool:
+        raise git.GitError("something gitpython does that we did not map")
 
-    def _fail_after_the_first(*args: object, **kwargs: object) -> object:
-        calls["n"] += 1
-        if calls["n"] > 1:
-            raise OSError(24, "Too many open files")
-        return real_run(*args, **kwargs)  # type: ignore[arg-type]
+    monkeypatch.setattr(git.Repo, "is_dirty", _boom)
 
-    monkeypatch.setattr(subprocess, "run", _fail_after_the_first)
-
-    with pytest.raises(BookshelfError, match="git could not be run"):
+    with pytest.raises(BookshelfError, match="git could not be queried"):
         derive_code_ref()
 
 
-def test_a_failure_carries_gits_own_stderr(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """The diagnosis must not sound more certain than the evidence behind it."""
-    monkeypatch.setenv("GIT_CEILING_DIRECTORIES", str(tmp_path))
-    monkeypatch.chdir(tmp_path)
-
-    with pytest.raises(BookshelfError, match="git said:"):
-        derive_code_ref()
-
-
-def test_a_repository_git_refuses_to_read_is_not_called_a_missing_repository(
+def test_a_repository_git_refuses_to_read_is_reported_as_such(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A non-zero exit proves the query failed, not that the usual cause applies.
+    """gitpython reads refs and config without git's validation.
 
-    This directory is a repository, so any message asserting otherwise is false.
+    This directory is a repository, so calling it missing or empty would be false.
+    Only a real git command surfaces the config it rejects, which is why one runs first.
     """
     _git(tmp_path, "init")
     (tmp_path / ".git" / "config").write_text("[core]\n\trepositoryformatversion = 99\n")
@@ -145,21 +147,17 @@ def test_a_repository_git_refuses_to_read_is_not_called_a_missing_repository(
         derive_code_ref()
 
     message = str(excinfo.value)
-    assert "usually because" in message
-    assert "git said:" in message
-    assert "found 99" in message
+    assert "refused to read" in message
+    assert "found 99" in message, "git's own stderr carries the specifics"
+    assert "no commits" not in message
 
 
-def test_a_repository_with_no_working_tree_is_reported_as_such(
+def test_a_bare_repository_is_reported_as_such(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A bare repository answers every other query, so only `git status` catches it."""
     source = tmp_path / "source"
     source.mkdir()
-    _git(source, "init")
-    (source / "a.txt").write_text("a")
-    _git(source, "add", "a.txt")
-    _git(source, "-c", "user.name=T", "-c", "user.email=t@example.com", "commit", "-m", "one")
+    _repo_with_a_commit(source)
 
     bare = tmp_path / "bare.git"
     subprocess.run(
@@ -167,8 +165,19 @@ def test_a_repository_with_no_working_tree_is_reported_as_such(
         check=True,
         capture_output=True,
     )
-    # The bare clone already carries an origin pointing at its source.
     monkeypatch.chdir(bare)
 
-    with pytest.raises(BookshelfError, match="could not read the working tree state"):
+    with pytest.raises(BookshelfError, match="repository is bare"):
         derive_code_ref()
+
+
+def test_a_subdirectory_resolves_the_containing_repository(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Builds run from anywhere in the tree, so the walk up to the repository root matters."""
+    _repo_with_a_commit(tmp_path)
+    nested = tmp_path / "notebooks" / "deep"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+
+    assert derive_code_ref().startswith("https://example.com/thing@")

--- a/packages/bookshelf/tests/test_provenance.py
+++ b/packages/bookshelf/tests/test_provenance.py
@@ -152,6 +152,27 @@ def test_a_repository_git_refuses_to_read_is_reported_as_such(
     assert "no commits" not in message
 
 
+def test_a_silent_git_failure_leaves_no_dangling_quote(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """git does not always write to stderr, and the message must still read cleanly."""
+    _repo_with_a_commit(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    def _fail_quietly(*args: object, **kwargs: object) -> bool:
+        raise git.GitCommandError(["git", "status"], 1, stderr="")
+
+    monkeypatch.setattr(git.Repo, "is_dirty", _fail_quietly)
+
+    with pytest.raises(BookshelfError) as excinfo:
+        derive_code_ref()
+
+    message = str(excinfo.value)
+    assert "refused to read" in message
+    assert "git said" not in message
+    assert message.endswith("Pass code_ref= explicitly.")
+
+
 def test_a_bare_repository_is_reported_as_such(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/bookshelf/tests/test_provenance.py
+++ b/packages/bookshelf/tests/test_provenance.py
@@ -19,7 +19,7 @@ def test_outside_a_repository_says_so(tmp_path: Path, monkeypatch: pytest.Monkey
     monkeypatch.setenv("GIT_CEILING_DIRECTORIES", str(tmp_path))
     monkeypatch.chdir(tmp_path)
 
-    with pytest.raises(BookshelfError, match="not inside a git repository"):
+    with pytest.raises(BookshelfError, match="could not identify a repository"):
         derive_code_ref()
 
 
@@ -29,7 +29,7 @@ def test_a_missing_origin_remote_names_the_remote(
     _git(tmp_path, "init")
     monkeypatch.chdir(tmp_path)
 
-    with pytest.raises(BookshelfError, match="no 'origin' remote"):
+    with pytest.raises(BookshelfError, match="could not read an 'origin' remote"):
         derive_code_ref()
 
 
@@ -40,7 +40,7 @@ def test_a_repository_with_no_commits_names_the_commit(
     _git(tmp_path, "remote", "add", "origin", "https://example.com/thing")
     monkeypatch.chdir(tmp_path)
 
-    with pytest.raises(BookshelfError, match="no commits"):
+    with pytest.raises(BookshelfError, match="could not resolve HEAD"):
         derive_code_ref()
 
 
@@ -130,6 +130,26 @@ def test_a_failure_carries_gits_own_stderr(tmp_path: Path, monkeypatch: pytest.M
         derive_code_ref()
 
 
+def test_a_repository_git_refuses_to_read_is_not_called_a_missing_repository(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-zero exit proves the query failed, not that the usual cause applies.
+
+    This directory is a repository, so any message asserting otherwise is false.
+    """
+    _git(tmp_path, "init")
+    (tmp_path / ".git" / "config").write_text("[core]\n\trepositoryformatversion = 99\n")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(BookshelfError) as excinfo:
+        derive_code_ref()
+
+    message = str(excinfo.value)
+    assert "usually because" in message
+    assert "git said:" in message
+    assert "found 99" in message
+
+
 def test_a_repository_with_no_working_tree_is_reported_as_such(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -150,5 +170,5 @@ def test_a_repository_with_no_working_tree_is_reported_as_such(
     # The bare clone already carries an origin pointing at its source.
     monkeypatch.chdir(bare)
 
-    with pytest.raises(BookshelfError, match="no working tree"):
+    with pytest.raises(BookshelfError, match="could not read the working tree state"):
         derive_code_ref()

--- a/packages/bookshelf/tests/test_provenance.py
+++ b/packages/bookshelf/tests/test_provenance.py
@@ -1,0 +1,86 @@
+"""Tests for bookshelf._produce.provenance: git-derived activity provenance."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bookshelf._core.errors import BookshelfError
+from bookshelf._produce.provenance import derive_code_ref
+
+
+def _git(cwd: Path, *args: str) -> None:
+    """Run one git command in ``cwd``, failing the test on a non-zero exit."""
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def test_outside_a_repository_says_so(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(BookshelfError, match="not inside a git repository"):
+        derive_code_ref()
+
+
+def test_a_missing_origin_remote_names_the_remote(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _git(tmp_path, "init")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(BookshelfError, match="no 'origin' remote"):
+        derive_code_ref()
+
+
+def test_a_repository_with_no_commits_names_the_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _git(tmp_path, "init")
+    _git(tmp_path, "remote", "add", "origin", "https://example.com/thing")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(BookshelfError, match="no commits"):
+        derive_code_ref()
+
+
+def test_a_clean_checkout_derives_remote_and_sha(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _git(tmp_path, "init")
+    _git(tmp_path, "remote", "add", "origin", "https://example.com/thing")
+    (tmp_path / "a.txt").write_text("a")
+    _git(tmp_path, "add", "a.txt")
+    _git(tmp_path, "-c", "user.name=T", "-c", "user.email=t@example.com", "commit", "-m", "one")
+    monkeypatch.chdir(tmp_path)
+
+    ref = derive_code_ref()
+
+    assert ref.startswith("https://example.com/thing@")
+    assert not ref.endswith("+dirty")
+
+
+def test_an_uncommitted_change_marks_the_ref_dirty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _git(tmp_path, "init")
+    _git(tmp_path, "remote", "add", "origin", "https://example.com/thing")
+    (tmp_path / "a.txt").write_text("a")
+    _git(tmp_path, "add", "a.txt")
+    _git(tmp_path, "-c", "user.name=T", "-c", "user.email=t@example.com", "commit", "-m", "one")
+    (tmp_path / "a.txt").write_text("changed")
+    monkeypatch.chdir(tmp_path)
+
+    assert derive_code_ref().endswith("+dirty")
+
+
+def test_a_missing_git_binary_is_reported_as_such(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    def _no_git(*args: object, **kwargs: object) -> None:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(subprocess, "run", _no_git)
+
+    with pytest.raises(BookshelfError, match="git is not installed"):
+        derive_code_ref()

--- a/packages/bookshelf/tests/test_provenance.py
+++ b/packages/bookshelf/tests/test_provenance.py
@@ -15,6 +15,8 @@ def _git(cwd: Path, *args: str) -> None:
 
 
 def test_outside_a_repository_says_so(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The ceiling stops git walking up, so the result does not depend on where TMPDIR sits.
+    monkeypatch.setenv("GIT_CEILING_DIRECTORIES", str(tmp_path))
     monkeypatch.chdir(tmp_path)
 
     with pytest.raises(BookshelfError, match="not inside a git repository"):
@@ -76,11 +78,31 @@ def test_a_missing_git_binary_is_reported_as_such(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.chdir(tmp_path)
-
-    def _no_git(*args: object, **kwargs: object) -> None:
-        raise FileNotFoundError("git")
-
-    monkeypatch.setattr(subprocess, "run", _no_git)
+    monkeypatch.setenv("PATH", "")
 
     with pytest.raises(BookshelfError, match="git is not installed"):
+        derive_code_ref()
+
+
+def test_a_repository_with_no_working_tree_is_reported_as_such(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bare repository answers every other query, so only `git status` catches it."""
+    source = tmp_path / "source"
+    source.mkdir()
+    _git(source, "init")
+    (source / "a.txt").write_text("a")
+    _git(source, "add", "a.txt")
+    _git(source, "-c", "user.name=T", "-c", "user.email=t@example.com", "commit", "-m", "one")
+
+    bare = tmp_path / "bare.git"
+    subprocess.run(
+        ["git", "clone", "--bare", str(source), str(bare)],
+        check=True,
+        capture_output=True,
+    )
+    # The bare clone already carries an origin pointing at its source.
+    monkeypatch.chdir(bare)
+
+    with pytest.raises(BookshelfError, match="no working tree"):
         derive_code_ref()

--- a/packages/bookshelf/tests/test_record_recipe.py
+++ b/packages/bookshelf/tests/test_record_recipe.py
@@ -55,6 +55,17 @@ def test_an_unknown_visibility_is_rejected_naming_the_allowed_values(tmp_path: P
         load_record_recipe(path)
 
 
+@pytest.mark.parametrize("value", ["[a]", "{a: b}", "3"])
+def test_a_visibility_that_is_not_a_string_stays_on_the_bookshelf_error_path(
+    tmp_path: Path, value: str
+) -> None:
+    """An unhashable value must not escape as a raw TypeError from the membership test."""
+    path = _write_recipe(tmp_path, f"visibility: {value}")
+
+    with pytest.raises(BookshelfError, match="visibility must be one of"):
+        load_record_recipe(path)
+
+
 def test_direct_setup_without_a_collection_points_at_the_recorder() -> None:
     """The message names the cause and both ways forward, not just a missing argument."""
     with pytest.raises(BookshelfError) as excinfo:

--- a/packages/bookshelf/tests/test_record_recipe.py
+++ b/packages/bookshelf/tests/test_record_recipe.py
@@ -1,0 +1,108 @@
+"""Tests for the slim record recipe and the framing bookshelf.setup resolves from it."""
+
+import textwrap
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from bookshelf._core.errors import BookshelfError
+from bookshelf._generated import models
+from bookshelf.publisher.bundle import Bundle
+from bookshelf.publisher.record import (
+    _ACTIVE_RECORDING,
+    _RecordingContext,
+    load_record_recipe,
+    setup,
+)
+
+
+def _write_recipe(tmp_path: Path, extra: str = "") -> Path:
+    """Write a minimal valid record recipe, plus any extra keys."""
+    path = tmp_path / "bookshelf.yaml"
+    path.write_text(
+        textwrap.dedent(
+            f"""\
+            collection: my-dataset
+            license: MIT
+            authors:
+              - name: Ada Lovelace
+                email: ada@example.com
+            notebook: build.py
+            {extra}
+            """
+        )
+    )
+    return path
+
+
+def test_visibility_is_optional(tmp_path: Path) -> None:
+    assert load_record_recipe(_write_recipe(tmp_path)).visibility is None
+
+
+@pytest.mark.parametrize("value", ["hidden", "org", "public"])
+def test_every_visibility_tier_is_accepted(tmp_path: Path, value: str) -> None:
+    recipe = load_record_recipe(_write_recipe(tmp_path, f"visibility: {value}"))
+
+    assert recipe.visibility == value
+
+
+def test_an_unknown_visibility_is_rejected_naming_the_allowed_values(tmp_path: Path) -> None:
+    path = _write_recipe(tmp_path, "visibility: everyone")
+
+    with pytest.raises(BookshelfError, match="visibility must be one of hidden, org, public"):
+        load_record_recipe(path)
+
+
+def test_direct_setup_without_a_collection_points_at_the_recorder() -> None:
+    """The message names the cause and both ways forward, not just a missing argument."""
+    with pytest.raises(BookshelfError) as excinfo:
+        setup(version="v1.0.0")
+
+    message = str(excinfo.value)
+    assert "no active recording" in message
+    assert "run_record" in message
+    assert "collection=" in message
+
+
+@contextmanager
+def _recording(recipe_path: Path, bundle_path: Path) -> Iterator[None]:
+    """Enter a recording context the way run_record does, without executing a notebook."""
+    context = _RecordingContext(
+        recipe=load_record_recipe(recipe_path),
+        bundle=Bundle(bundle_path),
+    )
+    token = _ACTIVE_RECORDING.set(context)
+    try:
+        yield
+    finally:
+        _ACTIVE_RECORDING.reset(token)
+        if context.bookshelf is not None:
+            context.bookshelf.close()
+
+
+def test_a_recorded_build_takes_its_visibility_from_the_recipe(tmp_path: Path) -> None:
+    recipe = _write_recipe(tmp_path, "visibility: public")
+
+    with _recording(recipe, tmp_path / "bundle"):
+        _, book = setup(version="v1.0.0")
+
+    assert book.metadata.visibility is models.Visibility.public
+
+
+def test_an_explicit_argument_still_overrides_the_recipe(tmp_path: Path) -> None:
+    recipe = _write_recipe(tmp_path, "visibility: public")
+
+    with _recording(recipe, tmp_path / "bundle"):
+        _, book = setup(version="v1.0.0", visibility="org")
+
+    assert book.metadata.visibility is models.Visibility.org
+
+
+def test_a_recipe_that_is_silent_leaves_the_book_hidden(tmp_path: Path) -> None:
+    """Neither caller nor recipe saying anything must not widen a book."""
+    with _recording(_write_recipe(tmp_path), tmp_path / "bundle"):
+        _, book = setup(version="v1.0.0")
+
+    assert book.metadata.visibility is models.Visibility.hidden

--- a/packages/bookshelf/tests/test_record_recipe.py
+++ b/packages/bookshelf/tests/test_record_recipe.py
@@ -111,6 +111,18 @@ def test_an_explicit_argument_still_overrides_the_recipe(tmp_path: Path) -> None
     assert book.metadata.visibility is models.Visibility.org
 
 
+def test_an_explicit_empty_visibility_never_inherits_the_recipe(tmp_path: Path) -> None:
+    """Invalid caller input must be rejected, not read as an omission.
+
+    Falling through here would widen the book to the recipe's `public`,
+    which is the one outcome this resolution must never produce by accident.
+    """
+    recipe = _write_recipe(tmp_path, "visibility: public")
+
+    with _recording(recipe, tmp_path / "bundle"), pytest.raises(ValueError):
+        setup(version="v1.0.0", visibility="")
+
+
 def test_a_recipe_that_is_silent_leaves_the_book_hidden(tmp_path: Path) -> None:
     """Neither caller nor recipe saying anything must not widen a book."""
     with _recording(_write_recipe(tmp_path), tmp_path / "bundle"):

--- a/uv.lock
+++ b/uv.lock
@@ -321,6 +321,7 @@ name = "bookshelf"
 version = "0.4.4a1"
 source = { editable = "packages/bookshelf" }
 dependencies = [
+    { name = "gitpython" },
     { name = "httpx" },
     { name = "keyring" },
     { name = "platformdirs" },
@@ -368,6 +369,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "gitpython", specifier = ">=3.1" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "ipykernel", marker = "extra == 'publish'", specifier = ">=6.0" },
     { name = "jupyter-client", marker = "extra == 'publish'", specifier = ">=8.0" },
@@ -1019,6 +1021,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.55"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932Z" },
 ]
 
 [[package]]
@@ -3468,6 +3494,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926", size = 34041, upload-time = "2021-05-05T14:18:18.379Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254", size = 11053, upload-time = "2021-05-05T14:18:17.237Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #136

Adds `gitpython` to the SDK's core dependencies with some fixes

## `derive_code_ref` reported four causes as one

One `except` covered git being absent, not being in a repository, having no `origin` remote and having no commits, then blamed the second one:

```
BookshelfError: Cannot derive code_ref: not inside a git repository
(or git is not available). Pass code_ref= explicitly.
```

A fresh feedstock has a repository and hits this on the remote. The message sends you to look at the wrong thing. Each cause now reports itself and names its own remedy.

The checks now go through `gitpython`. 

Three things worth flagging about that dependency:

- It does not remove the git binary requirement. `is_dirty()` still shells out, so git is needed either way.
- `gitpython` raises at *import* time when no git binary is found. As a core dependency that would break `import bookshelf` for every consumer who only reads books, so the import is lazy inside the provenance helper.

## Visibility can come from the recipe

`setup()` already resolves the licence as `license or context.recipe.license`, so the recipe is the declared home for framing. Visibility had no such path, which forced every build file to hardcode it while the collection, licence and authors sat in `bookshelf.yaml`. The template ended up scaffolding `visibility="public"`, so the least safe value lived in the least obvious place.

- `RecordRecipe` gains an optional `visibility`, added last so existing positional construction is unaffected.
- `load_record_recipe` reads it and rejects anything outside the three tiers, naming them.
- `setup()` resolves caller, then recipe, then `hidden`.

`setup(visibility=...)` changes from defaulting to `Visibility.hidden` to defaulting to `None`, so the recipe can be consulted. Callers passing an explicit value are unaffected, and callers relying on the default still get `hidden` when the recipe is silent. There is a test pinning that, because it is the case where a mistake would silently widen a book.

Worth noting `load_record_recipe` reads keys individually and ignores unknown ones, so before this a `visibility:` key in `bookshelf.yaml` was silently dropped. That is why the template could not simply declare it.

## Direct `setup` blamed the wrong thing

`direct setup requires collection` is accurate and useless. The author ran a notebook-shaped file the obvious way. It now says no recording is active, explains that the recorder supplies the collection from the recipe, and gives both ways forward.

## Noticed, not changed

- `load_record_recipe` still raises raw `FileNotFoundError`, `IsADirectoryError`, `PermissionError`, `UnicodeDecodeError` and `yaml.ParserError`, all pre-existing on the base branch and all confirmed by execution. A missing or malformed `bookshelf.yaml` is among the likeliest author mistakes there is, and it tracebacks rather than reporting. That is the same contract this branch is about, so it is the obvious next change, but it is not a regression here and widening the diff to cover it seemed wrong.
- A caller-supplied invalid `visibility` string still raises a raw `ValueError` from `draft_book`, so the recipe path and the argument path now disagree about validation. Worth aligning once the above is done.
- The two recipe schemas drift further apart here. `publisher.recipe.Recipe` sets `extra="forbid"` and carries `visibility` per book, so a record-mode `bookshelf.yaml` with a top-level `visibility:` is not loadable by `load_recipe`. They have separate consumers today, so nothing breaks, but nothing documents the record-mode key either and the slim recipe has no reference page at all.
- `_recording` in the tests hand-builds `_RecordingContext` rather than going through `run_record`, so it can drift from what the recorder actually sets. Going through `run_record` drags in notebook execution and git provenance for a test about one resolution order, so this seemed the right trade. Worth revisiting if the context grows.

- `make checks` runs `mypy src`, and there is no `src` at the repository root, so mypy is not actually enforced. That is why the 7 errors above sit unnoticed. Fixing the path makes the target fail loudly, so it wants its own change and a decision about the backlog.
