### PR TITLE
docs: refresh README, explanation and changelog guide

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+    # The default types omit ready_for_review, which would leave the jobs gated on
+    # `!draft` below permanently skipped on any pull request opened as a draft.
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
     tags: ['v*']

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-    # The default types omit ready_for_review, which would leave the jobs gated on
-    # `!draft` below permanently skipped on any pull request opened as a draft.
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,9 @@ checks:  ## run all the linting checks of the codebase
 ruff-fixes:  ## fix the code using ruff
     # format before and after checking so that the formatted stuff is checked and
     # the fixed stuff is formatted
-	uv run pre-commit run --all-files ruff-format
-	uv run pre-commit run --all-files ruff-check
+    # The hooks exit non-zero when they fix something, which is not a failure here.
+	-uv run pre-commit run --all-files ruff-format
+	-uv run pre-commit run --all-files ruff-check
 	uv run pre-commit run --all-files ruff-format
 
 .PHONY: test-sdk

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ruff-fixes:  ## fix the code using ruff
     # format before and after checking so that the formatted stuff is checked and
     # the fixed stuff is formatted
     # The hooks exit non-zero when they fix something, which is not a failure here.
-    # `make checks` is the gate that reports whether anything is left to fix.
+    # CI runs the same hooks without this suppression, so that is where a real problem surfaces.
 	-uv run pre-commit run --all-files ruff-format
 	-uv run pre-commit run --all-files ruff-check
 	-uv run pre-commit run --all-files ruff-format

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,10 @@ ruff-fixes:  ## fix the code using ruff
     # format before and after checking so that the formatted stuff is checked and
     # the fixed stuff is formatted
     # The hooks exit non-zero when they fix something, which is not a failure here.
+    # `make checks` is the gate that reports whether anything is left to fix.
 	-uv run pre-commit run --all-files ruff-format
 	-uv run pre-commit run --all-files ruff-check
-	uv run pre-commit run --all-files ruff-format
+	-uv run pre-commit run --all-files ruff-format
 
 .PHONY: test-sdk
 test-sdk:  ## run the tests for the SDK package

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,6 @@ checks:  ## run all the linting checks of the codebase
 
 .PHONY: ruff-fixes
 ruff-fixes:  ## fix the code using ruff
-    # format before and after checking so that the formatted stuff is checked and
-    # the fixed stuff is formatted
-    # The hooks exit non-zero when they fix something, which is not a failure here.
-    # CI runs the same hooks without this suppression, so that is where a real problem surfaces.
 	-uv run pre-commit run --all-files ruff-format
 	-uv run pre-commit run --all-files ruff-check
 	-uv run pre-commit run --all-files ruff-format

--- a/Makefile
+++ b/Makefile
@@ -31,16 +31,17 @@ help:  ## print short description of each target
 .PHONY: checks
 checks:  ## run all the linting checks of the codebase
 	@echo "=== pre-commit ==="; uv run pre-commit run --all-files || echo "--- pre-commit failed ---" >&2; \
-		echo "=== mypy ==="; MYPYPATH=stubs uv run mypy src || echo "--- mypy failed ---" >&2; \
+		echo "=== mypy ==="; \
+		(cd packages/bookshelf && uv run --locked --all-extras mypy src) || echo "--- mypy failed ---" >&2; \
 		echo "======"
 
 .PHONY: ruff-fixes
 ruff-fixes:  ## fix the code using ruff
     # format before and after checking so that the formatted stuff is checked and
     # the fixed stuff is formatted
-	uvx ruff@0.6.9 format
-	uvx ruff@0.6.9 check --fix
-	uvx ruff@0.6.9 format
+	uv run pre-commit run --all-files ruff-format
+	uv run pre-commit run --all-files ruff-check
+	uv run pre-commit run --all-files ruff-format
 
 .PHONY: test-sdk
 test-sdk:  ## run the tests for the SDK package
@@ -50,6 +51,11 @@ test-sdk:  ## run the tests for the SDK package
 
 .PHONY: test
 test: test-sdk  ## run the tests
+
+.PHONY: test-integration
+test-integration:  ## run the tests that talk to the real remote bookshelf
+	# Not run in CI because it depends on the remote bookshelf being up
+	uv run pytest tests/integration -r a -v
 
 
 # Note on code coverage and testing:
@@ -82,7 +88,7 @@ changelog-draft:  ## compile a draft of the next changelog
 licence-check:  ## Check that licences of the dependencies are suitable
 	# Will likely fail on Windows, but Makefiles are in general not Windows
 	# compatible so we're not too worried
-	uv export --without=tests --without=docs --without=dev > $(TEMP_FILE)
+	uv export --no-dev --no-emit-workspace --no-hashes --format requirements.txt > $(TEMP_FILE)
 	uv run liccheck -r $(TEMP_FILE) -R licence-check.txt
 	rm -f $(TEMP_FILE)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and command line authentication and discovery.
 [![PyPI](https://img.shields.io/pypi/v/bookshelf.svg)](https://pypi.org/project/bookshelf/)
 [![Python](https://img.shields.io/pypi/pyversions/bookshelf.svg)](https://pypi.org/project/bookshelf/)
 [![CI](https://github.com/climate-resource/bookshelf/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/climate-resource/bookshelf/actions/workflows/ci.yaml)
-[![Licence](https://img.shields.io/pypi/l/bookshelf?label=licence)](https://github.com/climate-resource/bookshelf/blob/main/LICENCE)
+[![Licence](https://img.shields.io/pypi/l/bookshelf?label=licence)](https://github.com/climate-resource/bookshelf/blob/main/LICENSE)
 
 This migration replaces the legacy Bookshelf consumer library.
 The retired `bookshelf-producer` distribution is not part of the workspace.

--- a/changelog/140.docs.md
+++ b/changelog/140.docs.md
@@ -1,0 +1,2 @@
+Rewrote the explanation page to cover why the SDK talks to an API rather than a storage bucket.
+Refreshed the changelog contribution guide and the notebooks README.

--- a/changelog/140.fix.md
+++ b/changelog/140.fix.md
@@ -1,0 +1,1 @@
+Fixed the licence badge in the README, which pointed at a `LICENCE` path that does not exist.

--- a/changelog/140.trivial.md
+++ b/changelog/140.trivial.md
@@ -2,3 +2,5 @@
   [SPEC 0](https://scientific-python.org/specs/spec-0000/).
 - Moved the `ruff-fixes` make target onto the pre-commit hooks,
   so there is a single pinned ruff version rather than two.
+- Added `ready_for_review` to the CI trigger,
+  so the linting and docs jobs run on a pull request that was opened as a draft.

--- a/changelog/140.trivial.md
+++ b/changelog/140.trivial.md
@@ -1,0 +1,2 @@
+Raised the development dependency lower bounds in line with [SPEC 0](https://scientific-python.org/specs/spec-0000/),
+and moved the `ruff-fixes` make target onto the pre-commit hooks so there is a single pinned ruff version.

--- a/changelog/140.trivial.md
+++ b/changelog/140.trivial.md
@@ -1,2 +1,4 @@
-Raised the development dependency lower bounds in line with [SPEC 0](https://scientific-python.org/specs/spec-0000/),
-and moved the `ruff-fixes` make target onto the pre-commit hooks so there is a single pinned ruff version.
+- Raised the development dependency lower bounds in line with
+  [SPEC 0](https://scientific-python.org/specs/spec-0000/).
+- Moved the `ruff-fixes` make target onto the pre-commit hooks,
+  so there is a single pinned ruff version rather than two.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,41 +1,42 @@
-# CHANGELOG
+# Changelog
 
-This directory contains "news fragments", i.e. short files that contain a small markdown-formatted bit of text that will be
-added to the CHANGELOG when it is next compiled.
+This directory contains news fragments.
+These are short markdown files that are assembled into the changelog
+the next time a release is cut.
 
-The CHANGELOG will be read by users, so this description should be aimed to bookshelf users instead of
-describing internal changes which are only relevant to developers. Merge requests in combination with our git history provides additional
-developer-centric information.
+The changelog is read by users of `bookshelf`,
+so write for them rather than describing internal changes.
+The git history and the pull requests already cover the developer view.
 
-Make sure to use phrases in the past tense and use punctuation, examples:
+Use the past tense and punctuate properly:
 
 ```
 Improved verbose diff output with sequences.
 
-Terminal summary statistics now use multiple colors.
+Terminal summary statistics now use multiple colours.
 ```
 
-Each file should have a name of the form `<MR>.<TYPE>.md`, where `<MR>` is the merge request number, and `<TYPE>` is one of:
+Each file is named `<PR>.<TYPE>.md`, where `<PR>` is the pull request number
+and `<TYPE>` is one of:
 
-* `feature`: new user facing features, like new command-line options and new behaviour.
-* `improvement`: improvement of existing functionality, usually without requiring user intervention
+* `feature`: new user facing features, like new command line options and new behaviour.
+* `improvement`: improvement of existing functionality, usually without requiring user intervention.
 * `fix`: fixes a bug.
-* `docs`: documentation improvement, like rewording an entire section or adding missing docs.
+* `docs`: documentation improvement, like rewording a section or adding missing docs.
 * `deprecation`: feature deprecation.
 * `breaking`: a change which may break existing uses, such as feature removal or behaviour change.
-* `trivial`: fixing a small typo or internal change that might be noteworthy.
+* `trivial`: a small typo or internal change that might be noteworthy.
 
-So for example: `123.feature.md`, `456.fix.md`.
+For example: `123.feature.md`, `456.fix.md`.
 
-Since you need the merge request number for the filename, you must submit a MR first. From this MR, you can get the MR number and then create the news file. A single MR can also have multiple news items, for example a given MR may add a feature as well as
-deprecate some existing functionality.
+You need the pull request number for the filename, so open the pull request first.
+A single pull request can carry more than one fragment,
+for example when it adds a feature and deprecates something at the same time.
 
-If you are not sure what issue type to use, don't hesitate to ask in your MR.
+If you are not sure which type to use, ask in the pull request.
 
-`towncrier` preserves multiple paragraphs and formatting (code blocks, lists, and so on), but for entries other than
-features it is usually better to stick to a single paragraph to keep it concise. You may also use `MyST` [style
-cross-referencing](https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html) within your news items to link to other
-documentation.
+`towncrier` preserves multiple paragraphs and formatting such as code blocks and lists.
+For anything other than a feature it is usually better to stick to one paragraph.
 
-You can also run `towncrier build --draft` to see the draft changelog that will be appended to [docs/source/changelog.md]()
-on the next release.
+Run `make changelog-draft` to preview what will be added to
+[docs/changelog.md](../docs/changelog.md) on the next release.

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -14,8 +14,7 @@ Every project that needs one ends up writing its own cleaning code.
 That has three costs.
 The same work is repeated.
 Two projects can silently disagree about what the same dataset says.
-Reproducing a result from a year ago means reconstructing whatever the cleaning
-code did at the time.
+Reproducing a result from a year ago means reconstructing whatever the cleaning code did at the time.
 
 `bookshelf` exists to pay that cost once.
 
@@ -36,39 +35,27 @@ which is what makes an analysis reproducible.
 **Versions and editions are separate.**
 The version tracks the upstream data.
 The edition tracks our processing of it.
-Splitting them means a consumer can tell whether a change came from the data provider
-or from us, which is usually the first question asked when a number moves.
+Splitting them means a consumer can tell whether a change came from the data provider or from us.
+That is usually the first question asked when a number moves.
 
 **Metadata travels with the data.**
-Each `Book` is a
-[datapackage](https://specs.frictionlessdata.io/data-package/)
-recording the licence, the source, the author and the hash of every file.
-The hashes are checked on download,
+Each `Book` carries its licence as an SPDX identifier,
+along with its source, its authors and a SHA256 hash for every resource.
+Hashes are checked on download,
 so a truncated or tampered file fails loudly rather than quietly producing wrong numbers.
 
-## Why a datapackage
+## Why timeseries are served in one shape
 
-We did not want to invent a metadata format.
-The frictionless
-[data package](https://specs.frictionlessdata.io/data-package/)
-specification already covers resources, hashes, licences and schemas,
-and it has tooling in several languages.
-A `Book` is a datapackage with a few extra fields,
-so a `Book` can be read by anything that already understands datapackages.
-
-## Why timeseries are stored in two shapes
-
-Most `Resource`s are timeseries, written in both wide and long form.
-
-Wide form has one row per timeseries and one column per year.
-It is what [scmdata](https://scmdata.readthedocs.io/) expects,
+Timeseries `Resource`s are stored wide,
+with one row per timeseries and one column per year.
+That is what [scmdata](https://scmdata.readthedocs.io/) expects,
 and it is compact for climate model work.
 
-Long form has one row per observation.
-It is what dataframe and database tooling expects,
-and it is much easier to join against other tables.
-
-Writing both costs a little storage and saves every consumer a reshape.
+Long form, with one row per observation, is what dataframe and database tooling expects.
+The SDK derives it on demand by melting the wide frame,
+so a consumer asks for the shape it wants without the store holding both.
+Storing one shape keeps a single copy of the numbers,
+which means the two shapes cannot drift apart.
 
 ## Why the notebooks are moving out
 
@@ -76,8 +63,8 @@ The notebooks in this repository were originally the only way to build a `Book`.
 That coupled every dataset's release cycle to this package's release cycle.
 A one line fix to a single dataset meant a new release of `bookshelf`.
 
-Datasets now live in their own feedstock repositories, scaffolded from a
-[copier template](https://github.com/climate-resource/copier-bookshelf-dataset).
+Datasets now live in their own feedstock repositories,
+scaffolded from a [copier template](https://github.com/climate-resource/copier-bookshelf-dataset).
 Each one releases on its own schedule and depends on `bookshelf` like any other user.
 The notebooks that remain here are kept as examples and as test fixtures.
 

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -40,22 +40,22 @@ That is usually the first question asked when a number moves.
 
 **Metadata travels with the data.**
 Each `Book` carries its licence as an SPDX identifier,
-along with its source, its authors and a SHA256 hash for every resource.
+and a SHA256 hash for every resource.
+The `Volume` above it carries the authors and the publisher.
 Hashes are checked on download,
 so a truncated or tampered file fails loudly rather than quietly producing wrong numbers.
 
-## Why timeseries are served in one shape
+## Why timeseries come in two shapes
 
-Timeseries `Resource`s are stored wide,
-with one row per timeseries and one column per year.
+Wide form has one row per timeseries and one column per year.
 That is what [scmdata](https://scmdata.readthedocs.io/) expects,
 and it is compact for climate model work.
-
 Long form, with one row per observation, is what dataframe and database tooling expects.
-The SDK derives it on demand by melting the wide frame,
-so a consumer asks for the shape it wants without the store holding both.
-Storing one shape keeps a single copy of the numbers,
-which means the two shapes cannot drift apart.
+
+A `Resource` is written in whichever shape produced it,
+and the SDK converts between the two on read.
+Asking for the wrong shape costs a reshape rather than an error,
+so a producer does not have to guess what its consumers will want.
 
 ## Why the notebooks are moving out
 
@@ -66,7 +66,7 @@ A one line fix to a single dataset meant a new release of `bookshelf`.
 Datasets now live in their own feedstock repositories,
 scaffolded from a [copier template](https://github.com/climate-resource/copier-bookshelf-dataset).
 Each one releases on its own schedule and depends on `bookshelf` like any other user.
-The notebooks that remain here are kept as examples and as test fixtures.
+The notebooks that remain here are being migrated out.
 
 ## Why the SDK talks to an API
 

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -16,7 +16,7 @@ The same work is repeated.
 Two projects can silently disagree about what the same dataset says.
 Reproducing a result from a year ago means reconstructing whatever the cleaning code did at the time.
 
-`bookshelf` exists to pay that cost once.
+`bookshelf` helps us deplicate that effort.
 
 ## The shape of the solution
 

--- a/docs/explanation.md
+++ b/docs/explanation.md
@@ -1,13 +1,99 @@
-This part of the project documentation
-will focus on an **understanding-oriented** approach.
-Here, we will describe the background of the project,
-as well as reasoning about how it was implemented.
+# Explanation
 
-Points we will aim to cover:
+This page covers the background of the project
+and the reasoning behind how it is put together.
 
-- Context and background on the library
-- Why it was created
-- Help the reader make connections
+## The problem
 
-We will aim to avoid writing instructions or technical descriptions here,
-they belong elsewhere.
+Climate Resource works on many projects that draw on the same public datasets.
+Those datasets are rarely usable as published.
+They arrive as spreadsheets, as zip files behind a login,
+or as CSVs whose column names change between releases.
+Every project that needs one ends up writing its own cleaning code.
+
+That has three costs.
+The same work is repeated.
+Two projects can silently disagree about what the same dataset says.
+Reproducing a result from a year ago means reconstructing whatever the cleaning
+code did at the time.
+
+`bookshelf` exists to pay that cost once.
+
+## The shape of the solution
+
+The processing for a dataset lives in a notebook, in version control.
+Running that notebook produces a `Book`, which is the processed dataset plus its metadata.
+`Book`s are uploaded to a remote store and fetched on demand by anything that needs them.
+
+Three properties do most of the work.
+
+**`Book`s are immutable.**
+Once published, a `Book` never changes.
+Fixing a mistake means publishing a new one.
+A project that pins a version and edition gets identical bytes every time,
+which is what makes an analysis reproducible.
+
+**Versions and editions are separate.**
+The version tracks the upstream data.
+The edition tracks our processing of it.
+Splitting them means a consumer can tell whether a change came from the data provider
+or from us, which is usually the first question asked when a number moves.
+
+**Metadata travels with the data.**
+Each `Book` is a
+[datapackage](https://specs.frictionlessdata.io/data-package/)
+recording the licence, the source, the author and the hash of every file.
+The hashes are checked on download,
+so a truncated or tampered file fails loudly rather than quietly producing wrong numbers.
+
+## Why a datapackage
+
+We did not want to invent a metadata format.
+The frictionless
+[data package](https://specs.frictionlessdata.io/data-package/)
+specification already covers resources, hashes, licences and schemas,
+and it has tooling in several languages.
+A `Book` is a datapackage with a few extra fields,
+so a `Book` can be read by anything that already understands datapackages.
+
+## Why timeseries are stored in two shapes
+
+Most `Resource`s are timeseries, written in both wide and long form.
+
+Wide form has one row per timeseries and one column per year.
+It is what [scmdata](https://scmdata.readthedocs.io/) expects,
+and it is compact for climate model work.
+
+Long form has one row per observation.
+It is what dataframe and database tooling expects,
+and it is much easier to join against other tables.
+
+Writing both costs a little storage and saves every consumer a reshape.
+
+## Why the notebooks are moving out
+
+The notebooks in this repository were originally the only way to build a `Book`.
+That coupled every dataset's release cycle to this package's release cycle.
+A one line fix to a single dataset meant a new release of `bookshelf`.
+
+Datasets now live in their own feedstock repositories, scaffolded from a
+[copier template](https://github.com/climate-resource/copier-bookshelf-dataset).
+Each one releases on its own schedule and depends on `bookshelf` like any other user.
+The notebooks that remain here are kept as examples and as test fixtures.
+
+## Why the SDK talks to an API
+
+Earlier versions read and wrote a public S3 bucket directly.
+That left several things unsolved.
+Publishing updated the volume metadata without any locking,
+so two people publishing the same volume at once could lose one of the updates.
+Access control was whatever the bucket provided,
+which meant the `private` flag hid a version from listings without protecting it.
+There was also no way to discover a volume without already knowing its name.
+
+The SDK talks to the Bookshelf API instead.
+Registration is transactional,
+so a partial publish fails as a whole rather than leaving a volume half updated.
+Authorisation is carried by a token bound to an organisation,
+so private data is genuinely private.
+Discovery is a query rather than a guess.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Bookshelf
 site_description: Curated set of climate data
 site_url: https://climate-resource.github.io/bookshelf
-edit_uri: blob/master/docs/
+edit_uri: blob/main/docs/
 
 repo_name: climate-resource/bookshelf
 repo_url: https://github.com/climate-resource/bookshelf

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -13,7 +13,4 @@ Start a feedstock repository from the
 The notebooks kept here are examples and test fixtures,
 and are being migrated out.
 
-`example_volume` is the minimal pair to copy when you want something to read.
-
-For more detail, see the
-[development docs](https://climate-resource.github.io/bookshelf/latest/development/).
+`example_volume` is the smallest working notebook and metadata file to read first.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,10 +1,19 @@
 # Notebooks
 
-This directory contains the notebooks used to produce the `Book`s. Each notebook
-corresponds with a single `Volume` (collection of `Book`s with the same `name`).
+This directory contains notebooks that produce `Book`s.
+Each notebook corresponds with a single `Volume`,
+which is the collection of `Book`s sharing a `name`.
 
-Each notebook also has a corresponding `.yaml` file containing the latest metadata
-for the `Book`. See the `NotebookMetadata` schema(`bookshelf.schema.NotebookMetadata`)
-for the expected format of this file.
+Each notebook has a matching `.yaml` file holding the metadata for the `Book`.
+See `example_volume/example_volume.yaml` for the expected format.
 
-For more details, see docs/source/notebooks.md
+New datasets should not be added here.
+Start a feedstock repository from the
+[copier template](https://github.com/climate-resource/copier-bookshelf-dataset) instead.
+The notebooks kept here are examples and test fixtures,
+and are being migrated out.
+
+`example_volume` is the minimal pair to copy when you want something to read.
+
+For more detail, see the
+[development docs](https://climate-resource.github.io/bookshelf/latest/development/).

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -10,7 +10,6 @@ See `example_volume/example_volume.yaml` for the expected format.
 New datasets should not be added here.
 Start a feedstock repository from the
 [copier template](https://github.com/climate-resource/copier-bookshelf-dataset) instead.
-The notebooks kept here are examples and test fixtures,
-and are being migrated out.
+The notebooks kept here are being migrated out.
 
 `example_volume` is the smallest working notebook and metadata file to read first.

--- a/packages/bookshelf/pyproject.toml
+++ b/packages/bookshelf/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "gitpython>=3.1",
@@ -28,7 +29,7 @@ bookshelf = "bookshelf._cli:main"
 [project.optional-dependencies]
 dataframes = [
     "polars>=1.0",
-    "pandas>=2.2",
+    "pandas>=2.3",
     "pyarrow>=16",
 ]
 scmrun = ["scmdata>=0.18"]

--- a/packages/bookshelf/pyproject.toml
+++ b/packages/bookshelf/pyproject.toml
@@ -3,6 +3,7 @@ name = "bookshelf"
 version = "0.4.4a1"
 description = "Python SDK for the Bookshelf data platform"
 readme = "README.md"
+# Lower bounds follow SPEC 0 (https://scientific-python.org/specs/spec-0000/).
 requires-python = ">=3.12"
 classifiers = [
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Jared Lewis", email = "jared.lewis@climate-resource.com" }
 ]
+# Lower bounds follow SPEC 0 (https://scientific-python.org/specs/spec-0000/).
 requires-python = ">=3.12"
 dependencies = [
     "bookshelf",
@@ -26,11 +27,15 @@ dev = [
     "pre-commit>=3.3.1",
     "towncrier>=23.6.0",
     "liccheck>=0.9.1",
+    # liccheck reaches into pkg_resources and pip internals, neither of which
+    # a uv-managed environment provides on its own
+    "setuptools<81",
+    "pip>=25",
     # Stubs
     "types-pyyaml>=6.0.12.20240917",
     "boto3-stubs[essential]>=1.35.39",
     "types-requests>=2.32.0.20240914",
-    "pandas-stubs>=2.2.3.241009",
+    "pandas-stubs>=2.3",
     # Docs
     "mkdocs>=1.6.0",
     "mkdocstrings[python]>=0.25.0",
@@ -43,7 +48,7 @@ dev = [
     "myst-nb>=1.1.1",
     "jupyterlab>=4.2.0",
     "jupytext>=1.16.3",
-    "matplotlib>=3.9.2",
+    "matplotlib>=3.10",
     "mike>=2.1.3",
     "mkdocs-minify-plugin>=0.8.0",
 ]
@@ -55,7 +60,7 @@ members = ["packages/*"]
 bookshelf = { workspace = true }
 
 [tool.coverage.run]
-source = ["src", "packages"]
+source = ["packages"]
 branch = true
 
 [tool.coverage.report]
@@ -105,7 +110,6 @@ formats = "ipynb,py:percent"
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",
-    "--ignore=packages/bookshelf/hatch_build.py"
 ]
 
 [tool.towncrier]
@@ -153,7 +157,25 @@ issue_format = "[#{issue}](https://github.com/climate-resource/bookshelf/pull/{i
   showcontent = false
 
 [tool.liccheck]
+# Packaging metadata now reports SPDX expressions (PEP 639) rather than the
+# long-form names, so both spellings have to be listed.
 authorized_licenses = [
+    # SPDX identifiers
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 OR BSD-2-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0",
+    "BSD-3-Clause AND ISC",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "MIT-CMU",
+    "MPL-2.0",
+    "MPL-2.0 AND MIT",
+    "PSF-2.0",
+    # Long-form names
     "bsd",
     "bsd license",
     "BSD 3-Clause",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ dev = [
     "pre-commit>=3.3.1",
     "towncrier>=23.6.0",
     "liccheck>=0.9.1",
-    # liccheck reaches into pkg_resources and pip internals, neither of which
-    # a uv-managed environment provides on its own
+    # liccheck reaches into pkg_resources and pip internals,
+    # neither of which a uv-managed environment provides on its own.
     "setuptools<81",
     "pip>=25",
     # Stubs
@@ -157,8 +157,8 @@ issue_format = "[#{issue}](https://github.com/climate-resource/bookshelf/pull/{i
   showcontent = false
 
 [tool.liccheck]
-# Packaging metadata now reports SPDX expressions (PEP 639) rather than the
-# long-form names, so both spellings have to be listed.
+# Packaging metadata reports licences as both SPDX expressions (PEP 639) and long-form names,
+# so both spellings have to be listed.
 authorized_licenses = [
     # SPDX identifiers
     "0BSD",

--- a/uv.lock
+++ b/uv.lock
@@ -426,6 +426,7 @@ dev = [
     { name = "mypy" },
     { name = "myst-nb" },
     { name = "pandas-stubs" },
+    { name = "pip" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -433,6 +434,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "requests-mock" },
     { name = "ruff" },
+    { name = "setuptools" },
     { name = "towncrier" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
@@ -447,7 +449,7 @@ dev = [
     { name = "jupyterlab", specifier = ">=4.2.0" },
     { name = "jupytext", specifier = ">=1.16.3" },
     { name = "liccheck", specifier = ">=0.9.1" },
-    { name = "matplotlib", specifier = ">=3.9.2" },
+    { name = "matplotlib", specifier = ">=3.10" },
     { name = "mike", specifier = ">=2.1.3" },
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-autorefs", specifier = ">=1.0.1" },
@@ -460,7 +462,8 @@ dev = [
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.25.0" },
     { name = "mypy", specifier = ">=1.2.0" },
     { name = "myst-nb", specifier = ">=1.1.1" },
-    { name = "pandas-stubs", specifier = ">=2.2.3.241009" },
+    { name = "pandas-stubs", specifier = ">=2.3" },
+    { name = "pip", specifier = ">=25" },
     { name = "pre-commit", specifier = ">=3.3.1" },
     { name = "pytest", specifier = ">=7.3.1" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
@@ -468,6 +471,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.3.1" },
     { name = "requests-mock", specifier = ">=1.11.0" },
     { name = "ruff", specifier = "==0.15.0" },
+    { name = "setuptools", specifier = "<81" },
     { name = "towncrier", specifier = ">=23.6.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20240917" },
     { name = "types-requests", specifier = ">=2.32.0.20240914" },
@@ -1782,7 +1786,7 @@ wheels = [
 
 [[package]]
 name = "matplotlib"
-version = "3.9.2"
+version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "contourpy" },
@@ -1796,25 +1800,43 @@ dependencies = [
     { name = "pyparsing" },
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/d8/3d7f706c69e024d4287c1110d74f7dabac91d9843b99eadc90de9efc8869/matplotlib-3.9.2.tar.gz", hash = "sha256:96ab43906269ca64a6366934106fa01534454a69e471b7bf3d79083981aaab92", size = 36088381, upload-time = "2024-08-13T01:45:36.875Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/de/54f7f38ce6de79cb77d513bb3eaa4e0b1031e9fd6022214f47943fa53a88/matplotlib-3.9.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ac43031375a65c3196bee99f6001e7fa5bdfb00ddf43379d3c0609bdca042df9", size = 7892511, upload-time = "2024-08-13T01:44:46.59Z" },
-    { url = "https://files.pythonhosted.org/packages/35/3e/5713b84a02b24b2a4bd4d6673bfc03017e6654e1d8793ece783b7ed4d484/matplotlib-3.9.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:be0fc24a5e4531ae4d8e858a1a548c1fe33b176bb13eff7f9d0d38ce5112a27d", size = 7769370, upload-time = "2024-08-13T01:44:48.084Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/bd/c404502aa1824456d2862dd6b9b0c1917761a51a32f7f83ff8cf94b6d117/matplotlib-3.9.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf81de2926c2db243c9b2cbc3917619a0fc85796c6ba4e58f541df814bbf83c7", size = 8193260, upload-time = "2024-08-13T01:44:49.663Z" },
-    { url = "https://files.pythonhosted.org/packages/27/75/de5b9cd67648051cae40039da0c8cbc497a0d99acb1a1f3d087cd66d27b7/matplotlib-3.9.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6ee45bc4245533111ced13f1f2cace1e7f89d1c793390392a80c139d6cf0e6c", size = 8306310, upload-time = "2024-08-13T01:44:51.329Z" },
-    { url = "https://files.pythonhosted.org/packages/de/e3/2976e4e54d7ee76eaf54b7639fdc10a223d05c2bdded7045233e9871e469/matplotlib-3.9.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:306c8dfc73239f0e72ac50e5a9cf19cc4e8e331dd0c54f5e69ca8758550f1e1e", size = 9086717, upload-time = "2024-08-13T01:44:53.772Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/92/c2b9464a0562feb6ae780bdc152364810862e07ef5e6affa2b7686028db2/matplotlib-3.9.2-cp312-cp312-win_amd64.whl", hash = "sha256:5413401594cfaff0052f9d8b1aafc6d305b4bd7c4331dccd18f561ff7e1d3bd3", size = 7832805, upload-time = "2024-08-13T01:44:55.947Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/7f/8932eac316b32f464b8f9069f151294dcd892c8fbde61fe8bcd7ba7f7f7e/matplotlib-3.9.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:18128cc08f0d3cfff10b76baa2f296fc28c4607368a8402de61bb3f2eb33c7d9", size = 7893012, upload-time = "2024-08-13T01:44:57.63Z" },
-    { url = "https://files.pythonhosted.org/packages/90/89/9db9db3dd0ff3e2c49e452236dfe29e60b5586a88f8928ca1d153d0da8b5/matplotlib-3.9.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4876d7d40219e8ae8bb70f9263bcbe5714415acfdf781086601211335e24f8aa", size = 7769810, upload-time = "2024-08-13T01:44:59.652Z" },
-    { url = "https://files.pythonhosted.org/packages/67/26/d2661cdc2e1410b8929c5f12dfd521e4528abfed1b3c3d5a28ac48258b43/matplotlib-3.9.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d9f07a80deab4bb0b82858a9e9ad53d1382fd122be8cde11080f4e7dfedb38b", size = 8193779, upload-time = "2024-08-13T01:45:01.453Z" },
-    { url = "https://files.pythonhosted.org/packages/95/70/4839eaa672bf4eacc98ebc8d23633e02b6daf39e294e7433c4ab11a689be/matplotlib-3.9.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7c0410f181a531ec4e93bbc27692f2c71a15c2da16766f5ba9761e7ae518413", size = 8306260, upload-time = "2024-08-13T01:45:03.107Z" },
-    { url = "https://files.pythonhosted.org/packages/88/62/7b263b2cb2724b45d3a4f9c8c6137696cc3ef037d44383fb01ac2a9555c2/matplotlib-3.9.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:909645cce2dc28b735674ce0931a4ac94e12f5b13f6bb0b5a5e65e7cea2c192b", size = 9086073, upload-time = "2024-08-13T01:45:04.757Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6d/3572fe243c74112fef120f0bc86f5edd21f49b60e8322fc7f6a01fe945dd/matplotlib-3.9.2-cp313-cp313-win_amd64.whl", hash = "sha256:f32c7410c7f246838a77d6d1eff0c0f87f3cb0e7c4247aebea71a6d5a68cab49", size = 7833041, upload-time = "2024-08-13T01:45:07.406Z" },
-    { url = "https://files.pythonhosted.org/packages/03/8f/9d505be3eb2f40ec731674fb6b47d10cc3147bbd6a9ea7a08c8da55415c6/matplotlib-3.9.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:37e51dd1c2db16ede9cfd7b5cabdfc818b2c6397c83f8b10e0e797501c963a03", size = 7933657, upload-time = "2024-08-13T01:45:08.967Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/68/44b458b9794bcff2a66921f8c9a8110a50a0bb099bd5f7cabb428a1dc765/matplotlib-3.9.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b82c5045cebcecd8496a4d694d43f9cc84aeeb49fe2133e036b207abe73f4d30", size = 7799276, upload-time = "2024-08-13T01:45:10.607Z" },
-    { url = "https://files.pythonhosted.org/packages/47/79/8486d4ddcaaf676314b5fb58e8fe19d1a6210a443a7c31fa72d4215fcb87/matplotlib-3.9.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f053c40f94bc51bc03832a41b4f153d83f2062d88c72b5e79997072594e97e51", size = 8221027, upload-time = "2024-08-13T01:45:12.204Z" },
-    { url = "https://files.pythonhosted.org/packages/56/62/72a472181578c3d035dcda0d0fa2e259ba2c4cb91132588a348bb705b70d/matplotlib-3.9.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dbe196377a8248972f5cede786d4c5508ed5f5ca4a1e09b44bda889958b33f8c", size = 8329097, upload-time = "2024-08-13T01:45:13.877Z" },
-    { url = "https://files.pythonhosted.org/packages/01/8a/760f7fce66b39f447ad160800619d0bd5d0936d2b4633587116534a4afe0/matplotlib-3.9.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5816b1e1fe8c192cbc013f8f3e3368ac56fbecf02fb41b8f8559303f24c5015e", size = 9093770, upload-time = "2024-08-13T01:45:15.562Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6c/7ef7ebcb2bd9739b2b66b18b076e077f44bb46fdbe28ca0506edb3c62c79/matplotlib-3.11.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e15ef41507f3d525f46154ac9e3ae785dacde9f20e593a25de8986267892ef74", size = 9453849, upload-time = "2026-07-18T03:38:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/f8/6d0c312c8d9738e7d9677f09fe5c986b3239e651a7b73a2deb38b65e4a71/matplotlib-3.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:21a67b961a6d597bca54fae826cd20695ba4a6e4d05424a08da6e13e3176fd6b", size = 9283113, upload-time = "2026-07-18T03:38:21.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/cf/b4ad2cc81b6672ea29ea04e64e350a9f9b493b0908ccd884c67eeff8f7b2/matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba8f811b8ddfac493734d6af0b2dff96919d0c28ca0d641858dab4262777c6ea", size = 10035615, upload-time = "2026-07-18T03:38:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/88/90/4e10e033d9b66589d8ed98b84c95cdbb57033d57c1f41339d7393dbd2f2e/matplotlib-3.11.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c52f7ad20ef476806ed212380b1d54d20310c8b86bdc2c9a68b51f0024a44472", size = 10842559, upload-time = "2026-07-18T03:38:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/88/eb/799612d0f8cd3e816a10fec59329fca52cd2353264df80378dfc541ae855/matplotlib-3.11.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8b14eb22961fe865efb0e4ff167e333e428908b00115a8d800ccb65ee108e481", size = 10927532, upload-time = "2026-07-18T03:38:28.532Z" },
+    { url = "https://files.pythonhosted.org/packages/88/89/56649bbaa2fd12e20f3be03dbcc135b0c8676d88bac17977599e3eb442a0/matplotlib-3.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:88a2a27dd9691ae448dfae4b26f59036be90c3c28757edd3553a29559d00859f", size = 9333886, upload-time = "2026-07-18T03:38:30.477Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/11/4d124efbbad677b7b7552f6f85a3bd432d4232f95400cea98fcd2ae36ef3/matplotlib-3.11.1-cp312-cp312-win_arm64.whl", hash = "sha256:480194afceca4df2f137c2721227d3cba67121fbf4397b69cee7f83714b0a58a", size = 9007545, upload-time = "2026-07-18T03:38:32.833Z" },
+    { url = "https://files.pythonhosted.org/packages/04/6c/4798363b7fb5644e309fe1fac30216e9146c9f70859d80d588c18caf5317/matplotlib-3.11.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6771b0cd7838c6a857a7209814158c0ad09bfef878db3033dd82d70ad101f191", size = 9454341, upload-time = "2026-07-18T03:38:35.001Z" },
+    { url = "https://files.pythonhosted.org/packages/59/98/6acadbe7f98df19d274bc107ac58bb439fa75df82c33dc110d71a4a8501f/matplotlib-3.11.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2abdee5ffa2fe11b2d19f7a5c63b785fb7c28cc46c7bc1814156341d9d1a33e1", size = 9283627, upload-time = "2026-07-18T03:38:37.061Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ea/65cec46fe241390ccea1b1754207ee28eb71c5ab866bd5f22fe47e538fa4/matplotlib-3.11.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0a19dcf73406d3746d25a5ed42d713604c9a3e024d129b102852b0d941cb9f3", size = 10035860, upload-time = "2026-07-18T03:38:39.663Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/10/63fdccccbabe002fb0960876baabc5e3f24d9c1bb4cfb25651457f74b3a0/matplotlib-3.11.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7389b77ed2ab0552f46d9a90b81b7b8e6dfcdc42adc36c37a0865799843e0e3e", size = 10843594, upload-time = "2026-07-18T03:38:42.144Z" },
+    { url = "https://files.pythonhosted.org/packages/98/51/a1155945bff7b91381875022ac1522c5dfdac0d006be8e7df389b3134eae/matplotlib-3.11.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c90be0b73568da4f662afac580956a76e308437e641b4a45aa08925eeb67d95f", size = 10927962, upload-time = "2026-07-18T03:38:44.302Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/3a/3d5e1f42dc761bf53401a62a83ff93389b37de9d2c093b2a3aa49ac34f1b/matplotlib-3.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:68408341f2312836fbbdf6b3c78047f65b2d8752f5fd221c3e72d348f5b34f8b", size = 9334074, upload-time = "2026-07-18T03:38:46.616Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/db/3f5ea5a5b64060ef5e1ff60a19170423e41ce21b8497a6fe15a36e0b43e3/matplotlib-3.11.1-cp313-cp313-win_arm64.whl", hash = "sha256:0c1f44890d435c1b4ef52f701ad5828cb450ea97bcc83918fda6be74965d6cd2", size = 9007662, upload-time = "2026-07-18T03:38:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6e/c7ae5e0531425b69c0826b00ebbc264c85cab853f1cd6e096c9983c2cdc1/matplotlib-3.11.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:5e510088c27a89d53580a752f959146893563e63c330e161d159b0fee652af6f", size = 9503790, upload-time = "2026-07-18T03:38:51.527Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/15be162e0a2ed546939674e2e97d0e33ec2447d86d4d4e611fa295bb178c/matplotlib-3.11.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:1524e2bdd48a93557aa47ddcfe9c225dfdd57d5a01a5c49128c20f0632980ee1", size = 9336148, upload-time = "2026-07-18T03:38:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7f/36ffe144fc4aacfe0e3ed2318f72b6755d1e73b041d619b4d393e60f5a66/matplotlib-3.11.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:11664c551345553db92e61cae6cf1376f138f8c47cafdf13b64b18f3e3e9e464", size = 10049244, upload-time = "2026-07-18T03:38:55.911Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/55812d68c0a840d3a463638f48c00ab1fe338518ec49a640cb6473b444af/matplotlib-3.11.1-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e1f8922ba31959cf6a9dfb51be64b7f7bc582801a3957dc0c2f3afcd3537adf", size = 10860798, upload-time = "2026-07-18T03:38:58.282Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/64/cca444b4eb5e6c768c44fc5e1f0b5211f20ca2b282778051996e996a2bdf/matplotlib-3.11.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83235693abde86e5e0129998f80ee39fc7f58e6d56a88fafb28a9278833e9d5f", size = 10943282, upload-time = "2026-07-18T03:39:00.465Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/0f/a49c329d394f2e9ef38506982107e8b04ecf94dd41a9d8423ff82cc737c7/matplotlib-3.11.1-cp313-cp313t-win_amd64.whl", hash = "sha256:9a076f4fc5cdc43fdf510f5981418d25c2db4973418d9f22d8bb3dc8045ada78", size = 9383532, upload-time = "2026-07-18T03:39:02.468Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/50/103e86afb806d8f64d04ede14e4cfc09dbfc25f512421ff85fdd6ebd59cf/matplotlib-3.11.1-cp313-cp313t-win_arm64.whl", hash = "sha256:216fbb93a74add02ddb4cb38ef5348f59ac00b3e84567eaf16598772d40e150a", size = 9059665, upload-time = "2026-07-18T03:39:04.607Z" },
+    { url = "https://files.pythonhosted.org/packages/35/04/3079499fa8cb661ea66d13d6439d5a3ae6710a7afd5c7f72e08914f275f8/matplotlib-3.11.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:30c492d4ba9448595b6fd8708c6725963f8148e25c0d8842948da5b05f0ee8d3", size = 9456022, upload-time = "2026-07-18T03:39:07.041Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a2/69acfe84ec1f32930e801a5782a07fc5c79c8c6599a507b806d859d5da8e/matplotlib-3.11.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ac104be2768ffdd8655db9e71b768cbb45f2b9aa7b450cf1595e8f65d3822319", size = 9285475, upload-time = "2026-07-18T03:39:09.562Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/31b15a2ca56d4ddd6aaa1c884c2f51cf9a61cfaf5ca6f6fbd6343d38e6df/matplotlib-3.11.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6be943cb68bc6660ead58c55b3aa6366cba2ef7feb06460fbcce32360376f19f", size = 10847102, upload-time = "2026-07-18T03:39:11.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0d/a17e966e620545c1548125af0b29ac812dd17b197a18a7462ac12fa859ee/matplotlib-3.11.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5af0dcda57d471440a7b5b623e70e0a61003518443d9098f211a96ecfbbc25be", size = 11131087, upload-time = "2026-07-18T03:39:13.764Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c5/5e100efdd67abb7de20befaa333612ef9bfc63417fb71398f904f25d083c/matplotlib-3.11.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3d3fd84082b1afbd9398466c81309e20045be20d48fe0fb18c43504d164cbbb2", size = 10929036, upload-time = "2026-07-18T03:39:16.888Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/d719a0a36930ecc8dfc801ff340f9dcfc4223f8ca5d39d06b4020032fff8/matplotlib-3.11.1-cp314-cp314-win_amd64.whl", hash = "sha256:9601a1e90be21e4884c53b4f3dc3ee0544654946f9975258d691f1c2e2f119c6", size = 9489571, upload-time = "2026-07-18T03:39:19.449Z" },
+    { url = "https://files.pythonhosted.org/packages/48/65/facabdc2f1f6caba7e856db64dfedddca25f7608df07d96a1c8fd114fd3b/matplotlib-3.11.1-cp314-cp314-win_arm64.whl", hash = "sha256:ae30c6109848ac0f9fa36c5d6270938487614c47ba31860bd5361266dabc5685", size = 9164486, upload-time = "2026-07-18T03:39:21.424Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/18da6cd01cf96354534f98c468a25380c68ce582a2c9dd0cae12b04af4f2/matplotlib-3.11.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dadfe80797174e2984aae3be0b77594a3c72d2c0a40fbd4a0de48d2728caf3ae", size = 9504876, upload-time = "2026-07-18T03:39:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b0/f0b63555a18b79d038c81fd6126f35fc4dfce0eaff48d96103348c7cf935/matplotlib-3.11.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:89b193b255f4f6f7948dbcee3691f4f341ab05d9a8874a67b45ddb4182922eda", size = 9336120, upload-time = "2026-07-18T03:39:25.797Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/dd/f210ec7c4a6f198d5567237048a93d0811fb5a1f1691f13320e592f95b41/matplotlib-3.11.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191163532cdefcb1571ca38a6d7e6474baccde64495783e6ba47aa07ec4b9bbb", size = 10858033, upload-time = "2026-07-18T03:39:27.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/d2/d6d5324507c5fbb316db48e258c09c2807f3de03d9af47017e120070926f/matplotlib-3.11.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9fdf1c818ab05d0e74002091ddaf414478a3a449ec9d51c8976d45be7e3a01e2", size = 11141827, upload-time = "2026-07-18T03:39:30.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/68/3c22e9320bdce2c4d2f1320643ef706db7a24cb7420eea28b97a2d67f5a8/matplotlib-3.11.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b937b9dba5f5f6c1e31c47abe2186c865c0914fd18f2ce0dfc39c9adcef5951d", size = 10943061, upload-time = "2026-07-18T03:39:32.356Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/4a/907ed190ee81a9df581e0ed5456134fc0f7cb55ffcfda2f9e54ca900761c/matplotlib-3.11.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f2912f647f3fbe1ccf085f91e213936f9101bead81a5e670565b1f1b3712f4fb", size = 9540074, upload-time = "2026-07-18T03:39:34.789Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d4/97c19b77e0a6e3b48581185bb65088f431cd20186076cc0f650a1757ea46/matplotlib-3.11.1-cp314-cp314t-win_arm64.whl", hash = "sha256:54d47b8ae8b579633a3902ca5b4ad6c1e132a5626d64447b2e22a66394e79987", size = 9213472, upload-time = "2026-07-18T03:39:37.141Z" },
 ]
 
 [[package]]
@@ -2549,16 +2571,15 @@ wheels = [
 
 [[package]]
 name = "pandas-stubs"
-version = "2.2.3.241009"
+version = "3.0.3.260530"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "types-pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/30/1ca31098512cdcfbc6ce366072848dff497880d4285281606b5895244bbc/pandas_stubs-2.2.3.241009.tar.gz", hash = "sha256:d4ab618253f0acf78a5d0d2bfd6dffdd92d91a56a69bdc8144e5a5c6d25be3b5", size = 103801, upload-time = "2024-10-09T14:55:57.276Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/aa/c41a8a0ff86fd85dbb3ec0c1f3fa488ca64a8b5f82654ae1b07d84acefe5/pandas_stubs-3.0.3.260530.tar.gz", hash = "sha256:d1efe47b2e5a312c047d7feabec5cb7a55365747983420077e9fcbe9ab74f714", size = 113183, upload-time = "2026-05-30T17:47:40.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/be/d9ba3109c4c19a78e125f63074c4e436e447f30ece15f0ef1865e7178233/pandas_stubs-2.2.3.241009-py3-none-any.whl", hash = "sha256:3a6f8f142105a42550be677ba741ba532621f4e0acad2155c0e7b2450f114cfa", size = 157883, upload-time = "2024-10-09T14:55:54.415Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e0/99ec5b02203c4e9ce878bc63d8caa06ac1f891e4d63bded9a5ced70fcb4f/pandas_stubs-3.0.3.260530-py3-none-any.whl", hash = "sha256:a6277eb1c8cebf48d9b2413fcd2e9a6b4ff479c934a223c29eacbc3058c4cb55", size = 173780, upload-time = "2026-05-30T17:47:39.13Z" },
 ]
 
 [[package]]
@@ -2677,6 +2698,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9a/30/b98b147073713f43efce50cfc6adbafdf52137a1baec59bbbc02021afbb9/pint_pandas-0.6.2.tar.gz", hash = "sha256:ec6bd1ab9c826d40fbd78ed05e1b014f7251319e0fe3f48312523accaf816b5e", size = 57841, upload-time = "2024-07-29T21:59:17.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/b0/2dcc0f58caf8d3bfc16df1214922fa826bbf7526145383872f257b903375/Pint_Pandas-0.6.2-py3-none-any.whl", hash = "sha256:dd2a1f50814e1b213e147d7380d37f7c079d6b9b58b0b7af90aa3b14124a64b2", size = 27463, upload-time = "2024-07-29T21:59:16.606Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]
@@ -3788,15 +3818,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/31/f8/f6ee4c803a7beccffee21bb29a71573b39f7037c224843eff53e5308c16e/types-python-dateutil-2.9.0.20241003.tar.gz", hash = "sha256:58cb85449b2a56d6684e41aeefb4c4280631246a0da1a719bdbe6f3fb0317446", size = 9210, upload-time = "2024-10-03T02:43:26.932Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/ba5f61958f358028f2e2ba1b8e225b8e263053bd57d3a79e2d2db64c807b/types_python_dateutil-2.9.0.20241003-py3-none-any.whl", hash = "sha256:250e1d8e80e7bbc3a6c99b907762711d1a1cdd00e978ad39cb5940f6f0a87f3d", size = 9693, upload-time = "2024-10-03T02:43:25.458Z" },
-]
-
-[[package]]
-name = "types-pytz"
-version = "2024.2.0.20241003"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/d0/73aa3063a9ef9881bd7103cb4ae379bfd8fafda0e86b01b694d676313a4b/types-pytz-2024.2.0.20241003.tar.gz", hash = "sha256:575dc38f385a922a212bac00a7d6d2e16e141132a3c955078f4a4fd13ed6cb44", size = 5474, upload-time = "2024-10-03T02:43:30.322Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/60/2a2977ce0f91255bbb668350b127a801a06ad37c326a2e5bfd52f03e0784/types_pytz-2024.2.0.20241003-py3-none-any.whl", hash = "sha256:3e22df1336c0c6ad1d29163c8fda82736909eb977281cb823c57f8bae07118b7", size = 5245, upload-time = "2024-10-03T02:43:29.492Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Carries the repo review changes forward onto the SDK branch. The review was originally done against `main`, so most of it targeted the legacy producer workspace and the old `packages/bookshelf` layout. Both are retired here, so roughly two thirds of the original work was dropped as obsolete rather than ported.

What lands:

- Rewrites `docs/explanation.md` to explain why the SDK talks to an API rather than an S3 bucket, replacing the old "known limits" section that described the bucket's missing locking, access control and discovery.
- Refreshes `changelog/README.md` for pull requests rather than merge requests, and points it at `make changelog-draft`.
- Refreshes `notebooks/README.md` to say new datasets belong in a feedstock repository, and to point at `example_volume` instead of a schema class that no longer exists.
- Raises the dev dependency lower bounds in line with [SPEC 0](https://scientific-python.org/specs/spec-0000/), and adds `setuptools<81` and `pip>=25` because liccheck reaches into `pkg_resources` and pip internals.
- Lists SPDX licence identifiers alongside the long-form names, because packaging metadata reports licences both ways.
- Replaces the pinned `uvx ruff@0.6.9` calls in the Makefile with the pre-commit hooks, so there is one ruff version rather than two. The fixing steps are prefixed with `-` because the hooks exit non-zero when they fix something, which would otherwise abort the target before `ruff-check` runs.
- Fixes the `uv export` call in the licence check target. It passed `--without=tests --without=docs --without=dev`, and `uv export` has no `--without` flag, so the target failed outright with `unexpected argument '--without' found`.
- Adds a `test-integration` make target, and points the `checks` mypy invocation at `packages/bookshelf` so it matches what CI runs.
- Narrows coverage `source` to `packages`, and drops the pytest ignore for `hatch_build.py`, which this base branch deletes.
- Fixes the licence badge, which pointed at a `LICENCE` path that does not exist, and the `edit_uri`, which pointed at `master`.
- Records in both `pyproject.toml` files that the `requires-python` floor follows SPEC 0. In `packages/bookshelf/pyproject.toml` that comment is the only change.

What was dropped, and why:

- The `click.MultiCommand` fix, the `hatch_build.py` removal and the `errors.py` and `utils.py` typing fixes all target modules this branch deletes. `UnknownEdition`, which carried a real bug, does not exist here at all.
- The CLI reference page documented the retired `bookshelf-producer` entry point.
- The README and `docs/development.md` rewrites were superseded by this branch's own rewrites of both files.

Python 3.14 does not land. The original review added it to both CI matrices, but it fails on the locked dependencies. `httpcore` raises `AttributeError: 'typing.Union' object has no attribute '__module__'` on import under 3.14, and `pyzmq` 26.2.0 has no 3.14 wheel. That needs a dependency bump first, so it is left out rather than shipped as a red matrix.

One thing worth a separate look: `packages/bookshelf/pyproject.toml` has no `authors` field on this base branch, so the SDK's PyPI metadata has no author. This PR does not change that.

Validated with the SDK test suite, mypy, pre-commit and `mkdocs build --strict`.

## Checklist

Please confirm that this pull request has done the following:

- [ ] Tests added
- [x] Documentation added (where applicable)
- [x] Changelog item added to `changelog/`
