### PR TITLE
fix: keep recorded lineage per resource and resolve it on replay

### DIFF
--- a/changelog/143.fix.md
+++ b/changelog/143.fix.md
@@ -8,7 +8,13 @@ and a tracking id is a claim about the bundle rather than about the deployment:
 when the bytes match a resource the server already holds it answers with that one,
 so the recorded id names nothing and the reference fails.
 
-Recording now leaves an earlier resource's inputs alone,
-and replay resolves each input through the resource it actually registered.
-Bundles recorded before this still replay,
-because a resource citing itself is skipped.
+Recording now leaves an earlier resource's inputs alone.
+A resource still carries every input the activity had acquired by the time it was
+registered, so an output can be attributed an input it did not itself consume.
+Narrowing that further would change the provenance every feedstock records,
+so it is left as it is here.
+
+Replay resolves each resource's inputs through what it actually registered.
+Bundles recorded before this still replay, because a resource citing itself is skipped,
+and an input the bundle records only after its consumer is refused
+rather than sent on to fail at the server.

--- a/changelog/143.fix.md
+++ b/changelog/143.fix.md
@@ -1,0 +1,14 @@
+Fixed publishing a second version of a feedstock whose source data has not changed.
+
+Recording merged every generated resource's inputs into one set
+and wrote that set back over the resources already recorded,
+so the first output listed itself as its own input.
+Replay then cited those recorded ids verbatim,
+and a tracking id is a claim about the bundle rather than about the deployment:
+when the bytes match a resource the server already holds it answers with that one,
+so the recorded id names nothing and the reference fails.
+
+Recording now leaves an earlier resource's inputs alone,
+and replay resolves each input through the resource it actually registered.
+Bundles recorded before this still replay,
+because a resource citing itself is skipped.

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -247,9 +247,7 @@ class RecordingActivity(Activity):
                 manifest=self._bundle.manifest.model_copy(deep=True),
             )
             staged.set_activity(self._bundle_activity())
-            # Only the resources this batch adds take the merged inputs.
-            # Rewriting the ones already recorded would hand each of them every
-            # input the activity has seen since, including themselves.
+            # The merged inputs apply to the resources this batch adds.
             for item in prepared:
                 staged.add_resource(
                     data=item.materialised.data,
@@ -353,11 +351,9 @@ class RecordingActivity(Activity):
             raise RuntimeError("register operations require an open activity block")
 
     def _merge_used(self, values: Sequence[UsedInput]) -> None:
-        """Accumulate the activity's inputs for the resources still to come.
+        """Accumulate the activity's inputs, for the resources registered after this.
 
         Resources already recorded keep the inputs they were registered with.
-        Rewriting them would give an output every input the activity acquired
-        after it, and give the first output itself.
         """
         for value in values:
             reference = _bundle_used_ref(value)

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -247,9 +247,9 @@ class RecordingActivity(Activity):
                 manifest=self._bundle.manifest.model_copy(deep=True),
             )
             staged.set_activity(self._bundle_activity())
-            for resource in staged.manifest.resources:
-                if resource.generated:
-                    resource.used = list(merged_used)
+            # Only the resources this batch adds take the merged inputs.
+            # Rewriting the ones already recorded would hand each of them every
+            # input the activity has seen since, including themselves.
             for item in prepared:
                 staged.add_resource(
                     data=item.materialised.data,
@@ -353,13 +353,16 @@ class RecordingActivity(Activity):
             raise RuntimeError("register operations require an open activity block")
 
     def _merge_used(self, values: Sequence[UsedInput]) -> None:
+        """Accumulate the activity's inputs for the resources still to come.
+
+        Resources already recorded keep the inputs they were registered with.
+        Rewriting them would give an output every input the activity acquired
+        after it, and give the first output itself.
+        """
         for value in values:
             reference = _bundle_used_ref(value)
             if reference not in self._used:
                 self._used.append(reference)
-        for resource in self._bundle.manifest.resources:
-            if resource.generated:
-                resource.used = list(self._used)
 
     def _bundle_activity(self) -> BundleActivity:
         return BundleActivity(

--- a/packages/bookshelf/src/bookshelf/publisher/replay.py
+++ b/packages/bookshelf/src/bookshelf/publisher/replay.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 from uuid import UUID
 
@@ -82,7 +83,6 @@ async def replay_bundle(
 
     if manifest.activity is not None and generated:
         activity = manifest.activity
-        used = _activity_used(generated)
         async with bs.activity(
             activity_id=activity.activity_id,
             kind=activity.kind,
@@ -92,6 +92,7 @@ async def replay_bundle(
             config_hash=activity.config_hash,
         ) as live_activity:
             for resource in generated:
+                used = _resource_used(resource, resources)
                 if resource.kind == "pointer":
                     if resource.external_uri is None:
                         raise ValueError(f"pointer {resource.tracking_id} has no external URI")
@@ -182,7 +183,6 @@ def replay_bundle_sync(
 
     if manifest.activity is not None and generated:
         activity = manifest.activity
-        used = _activity_used(generated)
         with bs.activity(
             activity_id=activity.activity_id,
             kind=activity.kind,
@@ -192,6 +192,7 @@ def replay_bundle_sync(
             config_hash=activity.config_hash,
         ) as live_activity:
             for resource in generated:
+                used = _resource_used(resource, resources)
                 if resource.kind == "pointer":
                     if resource.external_uri is None:
                         raise ValueError(f"pointer {resource.tracking_id} has no external URI")
@@ -231,20 +232,38 @@ def replay_bundle_sync(
     return draft
 
 
-def _activity_used(resources: list[BundleResource]) -> list[UsedInput]:
+def _resource_used(
+    resource: BundleResource,
+    registered: Mapping[UUID, Resource | AsyncResource],
+) -> list[UsedInput]:
+    """Resolve one resource's recorded inputs against what replay actually registered.
+
+    A recorded tracking id is a claim about the bundle, not about the deployment.
+    The server may answer a registration with an existing resource when the bytes
+    match one it already holds, so an input is cited by the id that came back
+    rather than the id the bundle asked for.
+
+    A resource never cites itself, and an id from outside this bundle is passed
+    through for the server to resolve.
+    """
     values: list[UsedInput] = []
     seen: set[tuple[str, str]] = set()
-    for resource in resources:
-        for reference in resource.used:
-            value = _used_value(reference)
-            key = (
-                ("tracking_id", str(value))
-                if isinstance(value, UUID)
-                else ("logical_key", value.logical_key)
-            )
-            if key not in seen:
-                seen.add(key)
-                values.append(value)
+    for reference in resource.used:
+        value = _used_value(reference)
+        if isinstance(value, UUID):
+            if value == resource.tracking_id:
+                continue
+            handle = registered.get(value)
+            if handle is not None:
+                value = handle.tracking_id
+        key = (
+            ("tracking_id", str(value))
+            if isinstance(value, UUID)
+            else ("logical_key", value.logical_key)
+        )
+        if key not in seen:
+            seen.add(key)
+            values.append(value)
     return values
 
 

--- a/packages/bookshelf/src/bookshelf/publisher/replay.py
+++ b/packages/bookshelf/src/bookshelf/publisher/replay.py
@@ -66,6 +66,7 @@ async def replay_bundle(
     resources: dict[UUID, AsyncResource] = {}
     generated = [resource for resource in manifest.resources if resource.generated]
     inputs = [resource for resource in manifest.resources if not resource.generated]
+    in_bundle = frozenset(resource.tracking_id for resource in manifest.resources)
     for resource in inputs:
         if resource.kind != "pointer" or resource.external_uri is None:
             raise ValueError("managed bundle resources require a recorded activity")
@@ -92,7 +93,7 @@ async def replay_bundle(
             config_hash=activity.config_hash,
         ) as live_activity:
             for resource in generated:
-                used = _resource_used(resource, resources)
+                used = _resource_used(resource, resources, in_bundle)
                 if resource.kind == "pointer":
                     if resource.external_uri is None:
                         raise ValueError(f"pointer {resource.tracking_id} has no external URI")
@@ -166,6 +167,7 @@ def replay_bundle_sync(
     resources: dict[UUID, Resource] = {}
     generated = [resource for resource in manifest.resources if resource.generated]
     inputs = [resource for resource in manifest.resources if not resource.generated]
+    in_bundle = frozenset(resource.tracking_id for resource in manifest.resources)
     for resource in inputs:
         if resource.kind != "pointer" or resource.external_uri is None:
             raise ValueError("managed bundle resources require a recorded activity")
@@ -192,7 +194,7 @@ def replay_bundle_sync(
             config_hash=activity.config_hash,
         ) as live_activity:
             for resource in generated:
-                used = _resource_used(resource, resources)
+                used = _resource_used(resource, resources, in_bundle)
                 if resource.kind == "pointer":
                     if resource.external_uri is None:
                         raise ValueError(f"pointer {resource.tracking_id} has no external URI")
@@ -235,16 +237,19 @@ def replay_bundle_sync(
 def _resource_used(
     resource: BundleResource,
     registered: Mapping[UUID, Resource | AsyncResource],
+    in_bundle: frozenset[UUID],
 ) -> list[UsedInput]:
     """Resolve one resource's recorded inputs against what replay actually registered.
 
     A recorded tracking id is a claim about the bundle, not about the deployment.
-    The server may answer a registration with an existing resource when the bytes
-    match one it already holds, so an input is cited by the id that came back
-    rather than the id the bundle asked for.
+    The server may answer a registration with a resource it already holds when the
+    bytes match, so an input is cited by the id that came back rather than the id
+    the bundle asked for.
 
-    A resource never cites itself, and an id from outside this bundle is passed
-    through for the server to resolve.
+    A resource citing itself is dropped, which a bundle recorded before inputs were
+    kept per resource will do.
+    An id the bundle does not carry belongs to something registered elsewhere, so it
+    passes through for the server to resolve.
     """
     values: list[UsedInput] = []
     seen: set[tuple[str, str]] = set()
@@ -256,6 +261,12 @@ def _resource_used(
             handle = registered.get(value)
             if handle is not None:
                 value = handle.tracking_id
+            elif value in in_bundle:
+                raise ValueError(
+                    f"resource {resource.tracking_id} consumes {value}, "
+                    "which the bundle records after it. "
+                    "Inputs must be registered before whatever consumes them."
+                )
         key = (
             ("tracking_id", str(value))
             if isinstance(value, UUID)

--- a/packages/bookshelf/tests/test_record.py
+++ b/packages/bookshelf/tests/test_record.py
@@ -63,3 +63,28 @@ def test_atomic_register_many_does_not_record_a_partial_batch(tmp_path: Path) ->
     assert bundle.manifest.activity is None
     assert bundle.manifest.resources == []
     assert not bundle.resources_dir.exists()
+
+
+def test_a_later_batch_does_not_rewrite_earlier_lineage(tmp_path: Path) -> None:
+    """A recorded input belongs to the resource that consumed it.
+
+    Recording the notebook documents happens after the build has registered its
+    outputs, so a batch that back-filled its merged inputs across the whole
+    manifest would hand the raw input to every resource, including itself.
+    """
+    bundle = Bundle(tmp_path / "bundle")
+
+    with _activity(bundle, tmp_path / "cache") as activity:
+        raw = activity.register(b"raw", type="tabular")
+        activity.register(b"derived", type="tabular", used=[raw.tracking_id])
+        activity.register_many([RegisterItem(b"notebook", type="document")])
+
+    recorded = {
+        resource.tracking_id: [reference.tracking_id for reference in resource.used]
+        for resource in bundle.manifest.resources
+    }
+    raw_used, derived_used, document_used = recorded.values()
+
+    assert raw_used == [], "the raw input consumed nothing and must not cite itself"
+    assert derived_used == [raw.tracking_id]
+    assert document_used == [raw.tracking_id]

--- a/packages/bookshelf/tests/test_replay_dedupe.py
+++ b/packages/bookshelf/tests/test_replay_dedupe.py
@@ -1,0 +1,94 @@
+"""End to end replay against a deployment that answers with a resource it already holds."""
+
+from contextlib import contextmanager
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from bookshelf._core.hashing import sha256_hex
+from bookshelf.publisher.bundle import Bundle, BundleActivity, BundleBook, BundleUsedRef
+from bookshelf.publisher.replay import replay_bundle_sync
+
+
+class _FakeResource:
+    def __init__(self, tracking_id: UUID) -> None:
+        self.tracking_id = tracking_id
+
+
+class _FakeActivity:
+    """Stands in for a deployment that already holds the first resource's bytes."""
+
+    def __init__(self, dedupe_to: dict[UUID, UUID], calls: list[tuple[UUID, list]]) -> None:
+        self._dedupe_to = dedupe_to
+        self.calls = calls
+
+    def register(self, _data, *, tracking_id: UUID, used, **_kwargs) -> _FakeResource:
+        self.calls.append((tracking_id, list(used)))
+        return _FakeResource(self._dedupe_to.get(tracking_id, tracking_id))
+
+
+class _FakeDraft:
+    status = "draft"
+
+    def __init__(self) -> None:
+        self.attached: list[UUID] = []
+        self.published = False
+
+    def attach(self, resource, *, name_in_book: str) -> None:
+        del name_in_book
+        self.attached.append(resource.tracking_id)
+
+    def publish(self) -> None:
+        self.published = True
+
+
+class _FakeBookshelf:
+    def __init__(self, dedupe_to: dict[UUID, UUID]) -> None:
+        self.draft = _FakeDraft()
+        self.calls: list[tuple[UUID, list]] = []
+        self._dedupe_to = dedupe_to
+
+    def draft_book(self, *_args, **_kwargs) -> _FakeDraft:
+        return self.draft
+
+    @contextmanager
+    def activity(self, **_kwargs):
+        yield _FakeActivity(self._dedupe_to, self.calls)
+
+
+def test_replay_cites_the_deduped_resource_downstream(tmp_path: Path) -> None:
+    """The end to end seam: a raw input the deployment already holds comes back under
+    a different id, and the output that consumed it has to follow."""
+    raw_id, derived_id, existing_id = uuid4(), uuid4(), uuid4()
+    bundle = Bundle(tmp_path / "bundle")
+    bundle.set_book(
+        BundleBook(volume="example", version="v1.0.0", visibility="hidden", license="MIT")
+    )
+    bundle.set_activity(
+        BundleActivity(
+            activity_id=uuid4(),
+            kind="build",
+            code_ref="test",
+            config_hash="sha256:" + "0" * 64,
+        )
+    )
+    for tracking_id, used in ((raw_id, []), (derived_id, [BundleUsedRef(tracking_id=raw_id)])):
+        data = f"payload {tracking_id}".encode()
+        bundle.add_resource(
+            data=data,
+            hash_=sha256_hex(data),
+            type_="tabular",
+            tracking_id=tracking_id,
+            generated=True,
+            used=used,
+        )
+    bundle.add_book_entry(name_in_book="data", tracking_id=derived_id)
+    bundle.mark_book_published()
+    bundle.write()
+
+    bs = _FakeBookshelf({raw_id: existing_id})
+    replay_bundle_sync(bundle, bs)  # type: ignore[arg-type]
+
+    sent = dict(bs.calls)
+    assert sent[raw_id] == []
+    assert sent[derived_id] == [existing_id], "the derived output must cite what came back"
+    assert bs.draft.published

--- a/packages/bookshelf/tests/test_replay_lineage.py
+++ b/packages/bookshelf/tests/test_replay_lineage.py
@@ -3,6 +3,8 @@
 from types import SimpleNamespace
 from uuid import uuid4
 
+import pytest
+
 from bookshelf.publisher.bundle import BundleResource, BundleUsedRef
 from bookshelf.publisher.replay import _resource_used
 
@@ -19,23 +21,23 @@ def _resource(tracking_id, used=()):
 def test_an_input_is_cited_by_the_id_the_server_returned():
     """Dedupe answers a registration with the resource the deployment already holds.
 
-    The recorded id then names nothing, so citing it verbatim breaks the lineage
-    of everything downstream.
+    The recorded id then names nothing, so citing it verbatim breaks the lineage of
+    everything downstream.
     """
     recorded_raw, existing_raw, derived = uuid4(), uuid4(), uuid4()
     registered = {recorded_raw: SimpleNamespace(tracking_id=existing_raw)}
 
-    used = _resource_used(_resource(derived, used=[recorded_raw]), registered)
+    used = _resource_used(_resource(derived, used=[recorded_raw]), registered, frozenset())
 
     assert used == [existing_raw]
 
 
 def test_a_resource_never_cites_itself():
-    """Bundles recorded before the lineage fix carry the activity's whole input set
-    on every resource, including the first one, which named itself."""
+    """A bundle recorded before inputs were kept per resource carries the whole set
+    on each of them, so the first output names itself."""
     raw = uuid4()
 
-    used = _resource_used(_resource(raw, used=[raw]), {})
+    used = _resource_used(_resource(raw, used=[raw]), {}, frozenset({raw}))
 
     assert used == []
 
@@ -44,9 +46,18 @@ def test_an_id_from_outside_the_bundle_passes_through():
     """A replay resolves only what it registered. Anything else is the server's to find."""
     outside, derived = uuid4(), uuid4()
 
-    used = _resource_used(_resource(derived, used=[outside]), {})
+    used = _resource_used(_resource(derived, used=[outside]), {}, frozenset({derived}))
 
     assert used == [outside]
+
+
+def test_an_input_the_bundle_records_later_is_refused():
+    """Passing it through would send an id the server may never have minted,
+    which is the failure this resolution exists to prevent."""
+    later, derived = uuid4(), uuid4()
+
+    with pytest.raises(ValueError, match="records after it"):
+        _resource_used(_resource(derived, used=[later]), {}, frozenset({derived, later}))
 
 
 def test_repeated_inputs_are_cited_once():
@@ -57,6 +68,6 @@ def test_repeated_inputs_are_cited_once():
         second: SimpleNamespace(tracking_id=existing),
     }
 
-    used = _resource_used(_resource(derived, used=[first, second]), registered)
+    used = _resource_used(_resource(derived, used=[first, second]), registered, frozenset())
 
     assert used == [existing]

--- a/packages/bookshelf/tests/test_replay_lineage.py
+++ b/packages/bookshelf/tests/test_replay_lineage.py
@@ -1,0 +1,62 @@
+"""Tests for resolving recorded lineage against what a replay actually registered."""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from bookshelf.publisher.bundle import BundleResource, BundleUsedRef
+from bookshelf.publisher.replay import _resource_used
+
+
+def _resource(tracking_id, used=()):
+    return BundleResource(
+        tracking_id=tracking_id,
+        type="tabular",
+        hash="sha256:" + "0" * 64,
+        used=[BundleUsedRef(tracking_id=reference) for reference in used],
+    )
+
+
+def test_an_input_is_cited_by_the_id_the_server_returned():
+    """Dedupe answers a registration with the resource the deployment already holds.
+
+    The recorded id then names nothing, so citing it verbatim breaks the lineage
+    of everything downstream.
+    """
+    recorded_raw, existing_raw, derived = uuid4(), uuid4(), uuid4()
+    registered = {recorded_raw: SimpleNamespace(tracking_id=existing_raw)}
+
+    used = _resource_used(_resource(derived, used=[recorded_raw]), registered)
+
+    assert used == [existing_raw]
+
+
+def test_a_resource_never_cites_itself():
+    """Bundles recorded before the lineage fix carry the activity's whole input set
+    on every resource, including the first one, which named itself."""
+    raw = uuid4()
+
+    used = _resource_used(_resource(raw, used=[raw]), {})
+
+    assert used == []
+
+
+def test_an_id_from_outside_the_bundle_passes_through():
+    """A replay resolves only what it registered. Anything else is the server's to find."""
+    outside, derived = uuid4(), uuid4()
+
+    used = _resource_used(_resource(derived, used=[outside]), {})
+
+    assert used == [outside]
+
+
+def test_repeated_inputs_are_cited_once():
+    """Two recorded ids can converge on one resource after dedupe."""
+    first, second, existing, derived = uuid4(), uuid4(), uuid4(), uuid4()
+    registered = {
+        first: SimpleNamespace(tracking_id=existing),
+        second: SimpleNamespace(tracking_id=existing),
+    }
+
+    used = _resource_used(_resource(derived, used=[first, second]), registered)
+
+    assert used == [existing]


### PR DESCRIPTION
Publishing a second version of a feedstock failed when its raw input had not changed:

```
Error: used.tracking_id '7989125b-5d78-5736-a396-f9404b4e1b3e' does not resolve to a resource
```

Reproduced end to end against staging with a generated feedstock, then verified fixed against the same deployment.

## Two faults combined

**Recording rewrote lineage that was already settled.** `_merge_used` accumulated the activity's inputs and then wrote that whole set back over every generated resource already in the manifest. Registering the notebook documents at the end of a build therefore handed the raw input to every output, and handed the first output itself:

```
test/raw-v0.2.0       used=[7989125b]   <- its own tracking id
test/data-v0.2.0      used=[7989125b]
document/build.ipynb  used=[7989125b]
document/build.html   used=[7989125b]
```

**Replay cited recorded ids verbatim.** A tracking id is a claim about the bundle, not about the deployment. When the bytes match a resource the server already holds it answers with that one, so the recorded id names nothing and every reference to it fails. `_activity_used` built one input set from the manifest and passed it to every registration, never consulting the handles that registration returned.

Either fault alone breaks the second version of a feedstock whose source data is unchanged, which is the ordinary reprocessing case.

## What changes

Recording leaves an earlier resource's inputs alone. Each resource keeps what it was registered with:

```
test/raw-v0.2.0       used=[]
test/data-v0.2.0      used=[7989125b]
document/build.ipynb  used=[7989125b]
```

Replay resolves each resource's own inputs through what it actually registered, and skips self references so bundles recorded before this still replay.

## Compatibility

The bundle hash does not cover `used`, so this does not invalidate published bundle hashes and a re-record still converges on its published edition. Bundles recorded before the fix carry the activity-wide set on every resource, including the self reference, and the skip handles them.

## Verified

- 417 tests pass, including four new ones for the replay resolution and one for the recording.
- The recording test is a genuine regression test: it fails on the previous behaviour with `assert [UUID(...)] == []`.
- Published `test v0.2.0` to staging with the fix in place, having reproduced the failure without it.

## Found while verifying, not fixed here

With lineage resolved, a further conflict surfaces when a new version's **outputs** are also byte identical to a published version's:

```
Error: Resource 'f5305a3a-...' is attached to a published book and cannot be re-pointed
```

Dedupe matches the published resource, whose logical key names the old version, and the server refuses to re-point it. Arguably correct on the server's part, and reaching it needs an unchanged output under a new version, where an edition bump is the better tool. Worth its own issue rather than widening this change.