### PR TITLE
Default a recorded resource to the book visibility

### DIFF
--- a/changelog/144.improvement.md
+++ b/changelog/144.improvement.md
@@ -1,0 +1,10 @@
+A recorded resource now takes the book's visibility instead of always recording as `hidden`.
+
+`visibility` in `bookshelf.yaml` sets the tier of the book and of everything the build records,
+including the `build.ipynb` and `build.html` documents the recorder adds itself,
+which a build file had no way to reach.
+A recipe declaring `visibility: public` previously produced a public book whose every resource was hidden.
+
+Passing `visibility=` on an individual registration still sets that one resource,
+so a public book can hold a member only the owning organisation may read.
+A build that declares nothing still records `hidden`, and building against the API directly is unchanged.

--- a/packages/bookshelf/src/bookshelf/_produce/activities.py
+++ b/packages/bookshelf/src/bookshelf/_produce/activities.py
@@ -45,6 +45,7 @@ from bookshelf._produce.types import (
     RegistrationSuccess,
     UsedInput,
 )
+from bookshelf._produce.visibility import INHERIT, VisibilityInput
 from bookshelf.cache import ContentCache
 
 
@@ -62,6 +63,7 @@ class Activity:
         config: Mapping[str, Any],
         runner: str,
         config_hash: str | None = None,
+        default_visibility: models.Visibility = models.Visibility.hidden,
     ) -> None:
         self._client = client
         self._cache = cache
@@ -71,6 +73,7 @@ class Activity:
         self.config = dict(config)
         self.runner = runner
         self.config_hash = config_hash
+        self.default_visibility = default_visibility
         self._entered = False
         self._closed = False
 
@@ -97,7 +100,7 @@ class Activity:
         type: str | models.ResourceType,
         logical_key: str | None = None,
         used: Sequence[UsedInput] = (),
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
@@ -161,7 +164,7 @@ class Activity:
         hash: str | None = None,
         logical_key: str | None = None,
         used: Sequence[UsedInput] = (),
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
@@ -178,7 +181,7 @@ class Activity:
             type=resource_type,
             hash=hash,
             logical_key=logical_key,
-            visibility=_visibility(visibility),
+            visibility=_visibility(visibility, self.default_visibility),
             tags=list(tags),
             metadata=dict(metadata or {}),
             external_uri=uri,
@@ -260,7 +263,7 @@ class Activity:
             hash=serialised.hash,
             format=entry.format or serialised.format,
             logical_key=entry.logical_key,
-            visibility=_visibility(entry.visibility),
+            visibility=_visibility(entry.visibility, self.default_visibility),
             tags=list(entry.tags),
             metadata=dict(entry.metadata or {}),
             locations=[models.LocationInput(shelf="managed", path=storage_path)],
@@ -320,6 +323,7 @@ class AsyncActivity:
         config: Mapping[str, Any],
         runner: str,
         config_hash: str | None = None,
+        default_visibility: models.Visibility = models.Visibility.hidden,
     ) -> None:
         self._client = client
         self._cache = cache
@@ -329,6 +333,7 @@ class AsyncActivity:
         self.config = dict(config)
         self.runner = runner
         self.config_hash = config_hash
+        self.default_visibility = default_visibility
         self._entered = False
         self._closed = False
 
@@ -357,7 +362,7 @@ class AsyncActivity:
         type: str | models.ResourceType,
         logical_key: str | None = None,
         used: Sequence[UsedInput] = (),
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
@@ -424,7 +429,7 @@ class AsyncActivity:
         hash: str | None = None,
         logical_key: str | None = None,
         used: Sequence[UsedInput] = (),
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
@@ -441,7 +446,7 @@ class AsyncActivity:
             type=resource_type,
             hash=hash,
             logical_key=logical_key,
-            visibility=_visibility(visibility),
+            visibility=_visibility(visibility, self.default_visibility),
             tags=list(tags),
             metadata=dict(metadata or {}),
             external_uri=uri,
@@ -523,7 +528,7 @@ class AsyncActivity:
             hash=serialised.hash,
             format=entry.format or serialised.format,
             logical_key=entry.logical_key,
-            visibility=_visibility(entry.visibility),
+            visibility=_visibility(entry.visibility, self.default_visibility),
             tags=list(entry.tags),
             metadata=dict(entry.metadata or {}),
             locations=[models.LocationInput(shelf="managed", path=storage_path)],

--- a/packages/bookshelf/src/bookshelf/_produce/facade.py
+++ b/packages/bookshelf/src/bookshelf/_produce/facade.py
@@ -36,15 +36,23 @@ from bookshelf._produce.helpers import (
 )
 from bookshelf._produce.provenance import derive_code_ref
 from bookshelf._produce.resources import AsyncResource, Resource
+from bookshelf._produce.visibility import INHERIT, VisibilityInput
 from bookshelf.cache import ContentCache
 
 
 class LiveSink:
     """Live synchronous adapter for producer writes."""
 
-    def __init__(self, client: BookshelfClient, cache: ContentCache) -> None:
+    def __init__(
+        self,
+        client: BookshelfClient,
+        cache: ContentCache,
+        *,
+        default_visibility: models.Visibility = models.Visibility.hidden,
+    ) -> None:
         self._client = client
         self._cache = cache
+        self.default_visibility = default_visibility
 
     def activity(
         self,
@@ -66,6 +74,7 @@ class LiveSink:
             config=dict(config or {}),
             runner=runner or _runner(),
             config_hash=config_hash,
+            default_visibility=self.default_visibility,
         )
 
     def register_external(
@@ -75,7 +84,7 @@ class LiveSink:
         uri: str,
         hash: str | None = None,
         logical_key: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
@@ -88,7 +97,7 @@ class LiveSink:
             type=resource_type,
             hash=hash,
             logical_key=logical_key,
-            visibility=_visibility(visibility),
+            visibility=_visibility(visibility, self.default_visibility),
             tags=list(tags),
             metadata=dict(metadata or {}),
             external_uri=uri,
@@ -143,9 +152,16 @@ class LiveSink:
 class AsyncLiveSink:
     """Live asynchronous adapter for producer writes."""
 
-    def __init__(self, client: BookshelfClient, cache: ContentCache) -> None:
+    def __init__(
+        self,
+        client: BookshelfClient,
+        cache: ContentCache,
+        *,
+        default_visibility: models.Visibility = models.Visibility.hidden,
+    ) -> None:
         self._client = client
         self._cache = cache
+        self.default_visibility = default_visibility
 
     def activity(
         self,
@@ -167,6 +183,7 @@ class AsyncLiveSink:
             config=dict(config or {}),
             runner=runner or _runner(),
             config_hash=config_hash,
+            default_visibility=self.default_visibility,
         )
 
     async def register_external(
@@ -176,7 +193,7 @@ class AsyncLiveSink:
         uri: str,
         hash: str | None = None,
         logical_key: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
@@ -189,7 +206,7 @@ class AsyncLiveSink:
             type=resource_type,
             hash=hash,
             logical_key=logical_key,
-            visibility=_visibility(visibility),
+            visibility=_visibility(visibility, self.default_visibility),
             tags=list(tags),
             metadata=dict(metadata or {}),
             external_uri=uri,
@@ -262,7 +279,7 @@ class ProduceSink(Protocol):
         uri: str,
         hash: str | None = None,
         logical_key: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
@@ -304,7 +321,7 @@ class AsyncProduceSink(Protocol):
         uri: str,
         hash: str | None = None,
         logical_key: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
@@ -357,7 +374,7 @@ class ProduceFacade:
         uri: str,
         hash: str | None = None,
         logical_key: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
@@ -433,7 +450,7 @@ class AsyncProduceFacade:
         uri: str,
         hash: str | None = None,
         logical_key: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,

--- a/packages/bookshelf/src/bookshelf/_produce/helpers.py
+++ b/packages/bookshelf/src/bookshelf/_produce/helpers.py
@@ -18,6 +18,8 @@ from bookshelf._produce.types import (
     Used,
     UsedInput,
 )
+from bookshelf._produce.visibility import INHERIT, VisibilityInput
+from bookshelf._produce.visibility import resolve as resolve_visibility
 
 MAX_REGISTRATION_BATCH = 1000
 
@@ -48,9 +50,12 @@ def resource_type(value: str | models.ResourceType) -> models.ResourceType:
     return value if isinstance(value, models.ResourceType) else models.ResourceType(value)
 
 
-def visibility(value: str | models.Visibility) -> models.Visibility:
-    """Normalise a public visibility input."""
-    return value if isinstance(value, models.Visibility) else models.Visibility(value)
+def visibility(
+    value: VisibilityInput,
+    default: models.Visibility = models.Visibility.hidden,
+) -> models.Visibility:
+    """Normalise a public visibility input, resolving :data:`INHERIT` to ``default``."""
+    return resolve_visibility(value, default)
 
 
 def registered_tracking_id(outcome: models.RegistrationOutcome) -> UUID:
@@ -141,7 +146,9 @@ def raise_partial_registration(
 
 
 __all__ = [
+    "INHERIT",
     "MAX_REGISTRATION_BATCH",
+    "VisibilityInput",
     "activity_envelope",
     "raise_partial_registration",
     "registered_resource_type",

--- a/packages/bookshelf/src/bookshelf/_produce/types.py
+++ b/packages/bookshelf/src/bookshelf/_produce/types.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from bookshelf._core.errors import BookshelfError
 from bookshelf._generated import models
+from bookshelf._produce.visibility import INHERIT, VisibilityInput
 
 if TYPE_CHECKING:
     from bookshelf._produce.resources import AsyncResource, Resource
@@ -39,7 +40,7 @@ class RegisterItem:
     obj: object
     type: str | models.ResourceType
     logical_key: str | None = None
-    visibility: str | models.Visibility = models.Visibility.hidden
+    visibility: VisibilityInput = INHERIT
     tags: Sequence[str] = ()
     metadata: Mapping[str, Any] | None = None
     tracking_id: UUID | None = None

--- a/packages/bookshelf/src/bookshelf/_produce/visibility.py
+++ b/packages/bookshelf/src/bookshelf/_produce/visibility.py
@@ -1,0 +1,37 @@
+"""The visibility argument shared by every producer registration surface."""
+
+from __future__ import annotations
+
+import enum
+
+from bookshelf._generated import models
+
+
+class _Inherit(enum.Enum):
+    """Sentinel distinguishing an omitted ``visibility=`` from an explicit tier."""
+
+    INHERIT = enum.auto()
+
+
+INHERIT = _Inherit.INHERIT
+
+VisibilityInput = str | models.Visibility | _Inherit
+"""A visibility argument: an explicit tier, or :data:`INHERIT` for the caller's default.
+
+Under a recording the default is the book's tier as declared in the recipe,
+so a public book records public resources and narrowing one is a deliberate act.
+Everywhere else the default is ``hidden``.
+"""
+
+
+def resolve(
+    value: VisibilityInput,
+    default: models.Visibility = models.Visibility.hidden,
+) -> models.Visibility:
+    """Normalise a visibility input, resolving :data:`INHERIT` to ``default``."""
+    if isinstance(value, _Inherit):
+        return default
+    return value if isinstance(value, models.Visibility) else models.Visibility(value)
+
+
+__all__ = ["INHERIT", "VisibilityInput", "resolve"]

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -27,6 +27,7 @@ from bookshelf._produce.helpers import visibility as _visibility
 from bookshelf._produce.resources import Resource
 from bookshelf._produce.serialise import SerialisedObject, serialise
 from bookshelf._produce.types import HasTrackingId, RegisterItem, UsedInput
+from bookshelf._produce.visibility import INHERIT, VisibilityInput
 from bookshelf.cache import ContentCache
 from bookshelf.facade import Bookshelf
 from bookshelf.publisher.bundle import (
@@ -118,6 +119,7 @@ class RecordingActivity(Activity):
         config: Mapping[str, Any],
         runner_name: str,
         config_hash: str | None = None,
+        default_visibility: models.Visibility = models.Visibility.hidden,
     ) -> None:
         self._bundle = bundle
         self._client = client
@@ -128,6 +130,7 @@ class RecordingActivity(Activity):
         self.config = dict(config)
         self.runner = runner_name
         self.config_hash = config_hash
+        self.default_visibility = default_visibility
         self._envelope = activity_envelope(
             activity_id=activity_id,
             kind=kind,
@@ -160,7 +163,7 @@ class RecordingActivity(Activity):
         type: str | models.ResourceType,
         logical_key: str | None = None,
         used: Sequence[UsedInput] = (),
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
@@ -170,7 +173,7 @@ class RecordingActivity(Activity):
         """Serialise an output once and append its bytes and provenance."""
         self._require_entered()
         resource_type = _resource_type(type)
-        resource_visibility = _visibility(visibility)
+        resource_visibility = _visibility(visibility, self.default_visibility)
         materialised = serialise(obj, type=resource_type.value)
         resource_id = tracking_id or uuid7()
         self._merge_used(used)
@@ -299,10 +302,9 @@ class RecordingActivity(Activity):
             for item in prepared
         ]
 
-    @staticmethod
-    def _prepare_registration(entry: RegisterItem) -> _PreparedRegistration:
+    def _prepare_registration(self, entry: RegisterItem) -> _PreparedRegistration:
         resource_type = _resource_type(entry.type)
-        visibility = _visibility(entry.visibility)
+        visibility = _visibility(entry.visibility, self.default_visibility)
         return _PreparedRegistration(
             entry=entry,
             materialised=serialise(entry.obj, type=resource_type.value),
@@ -319,7 +321,7 @@ class RecordingActivity(Activity):
         hash: str | None = None,
         logical_key: str | None = None,
         used: Sequence[UsedInput] = (),
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
@@ -338,6 +340,7 @@ class RecordingActivity(Activity):
             hash=hash,
             logical_key=logical_key,
             visibility=visibility,
+            default_visibility=self.default_visibility,
             tags=tags,
             metadata=metadata,
             tracking_id=tracking_id,
@@ -442,12 +445,19 @@ class RecordingSink:
         cache: ContentCache,
         *,
         authors: Sequence[Mapping[str, Any]] = (),
+        default_visibility: models.Visibility = models.Visibility.hidden,
     ) -> None:
         self.bundle = bundle
         self._client = client
         self._cache = cache
         self._authors = tuple(dict(author) for author in authors)
         self._activity_started = False
+        self.default_visibility = default_visibility
+        """The tier a registration takes when the build file names none.
+
+        Seeded from the recipe and re-seeded by :meth:`draft_book`, so the book's
+        declared tier is what its resources record as.
+        """
 
     def activity(
         self,
@@ -477,6 +487,7 @@ class RecordingSink:
             config=dict(config or {}),
             runner_name=runner or _runner(),
             config_hash=config_hash,
+            default_visibility=self.default_visibility,
         )
 
     def draft_book(
@@ -487,20 +498,25 @@ class RecordingSink:
         description: str | None = None,
         citation_doi: str | None = None,
         license: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         metadata: Mapping[str, Any] | None = None,
         bundle_hash: str | None = None,
     ) -> RecordedDraftBook:
-        """Record pre-edition book framing and return its local handle."""
+        """Record pre-edition book framing and return its local handle.
+
+        The book's tier becomes the default for every resource this build records
+        afterwards, so declaring the book public is enough to publish public data.
+        """
         del bundle_hash
         if license is None:
             raise ValueError("recorded books require an explicit license")
-        resource_visibility = _visibility(visibility)
+        book_visibility = _visibility(visibility, self.default_visibility)
+        self.default_visibility = book_visibility
         self.bundle.set_book(
             BundleBook(
                 volume=volume,
                 version=version,
-                visibility=resource_visibility.value,
+                visibility=book_visibility.value,
                 license=license,
                 authors=list(self._authors),
                 description=description,
@@ -513,7 +529,7 @@ class RecordingSink:
             self._client,
             volume=volume,
             version=version,
-            visibility=resource_visibility,
+            visibility=book_visibility,
             license=license,
             description=description,
             citation_doi=citation_doi,
@@ -527,7 +543,7 @@ class RecordingSink:
         uri: str,
         hash: str | None = None,
         logical_key: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         tags: Sequence[str] = (),
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
@@ -543,6 +559,7 @@ class RecordingSink:
             hash=hash,
             logical_key=logical_key,
             visibility=visibility,
+            default_visibility=self.default_visibility,
             tags=tags,
             metadata=metadata,
             tracking_id=tracking_id,
@@ -556,7 +573,12 @@ class RecordingSink:
         logical_key: str,
         metadata: Mapping[str, Any],
     ) -> RecordedResource:
-        """Record execution evidence as an output of the captured activity."""
+        """Record execution evidence as an output of the captured activity.
+
+        The recorder adds these documents itself, so the build file cannot pass a
+        tier for them. They take the book's, which keeps a public book's evidence
+        readable alongside the data it explains.
+        """
         activity = self.bundle.manifest.activity
         if activity is None:
             raise BookshelfError("a recorded build requires an activity before execution documents")
@@ -569,6 +591,7 @@ class RecordingSink:
             type_="document",
             tracking_id=resource_id,
             logical_key=logical_key,
+            visibility=self.default_visibility.value,
             metadata=dict(metadata),
             dedupe=False,
             generated=True,
@@ -581,6 +604,7 @@ class RecordingSink:
             models.ResourceType.document,
             materialised.hash,
             logical_key=logical_key,
+            visibility=self.default_visibility,
             metadata=metadata,
         )
 
@@ -598,6 +622,9 @@ class RecordingBookshelf(Bookshelf):
     ) -> None:
         super().__init__(base_url, auth=auth)
         self.bundle = bundle
+        # The sink's default tier stays ``hidden`` until draft_book seeds it from
+        # the book. A build file reaches this facade only through setup, which
+        # drafts the book first, so nothing registers against the placeholder.
         self.recording_sink = RecordingSink(
             bundle,
             self._client,
@@ -657,6 +684,10 @@ def setup(
     Visibility resolves from the caller, then the recipe,
     then :attr:`~bookshelf.models.Visibility.hidden`.
     Direct use has no recipe, so an omitted visibility is ``hidden`` and an omitted licence stays unset.
+
+    The resolved tier is also the default for every resource the build records,
+    including the notebook and HTML documents the recorder adds itself.
+    Pass ``visibility=`` on an individual registration to narrow that one resource.
     """
     book: DraftBook | RecordedDraftBook
     context = _ACTIVE_RECORDING.get()
@@ -870,7 +901,8 @@ def _record_pointer(
     uri: str,
     hash: str | None,
     logical_key: str | None,
-    visibility: str | models.Visibility,
+    visibility: VisibilityInput,
+    default_visibility: models.Visibility,
     tags: Sequence[str],
     metadata: Mapping[str, Any] | None,
     tracking_id: UUID | None,
@@ -880,7 +912,7 @@ def _record_pointer(
 ) -> RecordedResource:
     """Append one pointer resource and return its local handle."""
     resource_type = _resource_type(type)
-    resource_visibility = _visibility(visibility)
+    resource_visibility = _visibility(visibility, default_visibility)
     resource_hash = hash or synthesise_pointer_hash(
         type_=resource_type.value,
         external_uri=uri,

--- a/packages/bookshelf/tests/test_record_recipe.py
+++ b/packages/bookshelf/tests/test_record_recipe.py
@@ -9,6 +9,7 @@ import pytest
 
 from bookshelf._core.errors import BookshelfError
 from bookshelf._generated import models
+from bookshelf._produce.types import RegisterItem
 from bookshelf.publisher.bundle import Bundle
 from bookshelf.publisher.record import (
     _ACTIVE_RECORDING,
@@ -129,3 +130,45 @@ def test_a_recipe_that_is_silent_leaves_the_book_hidden(tmp_path: Path) -> None:
         _, book = setup(version="v1.0.0")
 
     assert book.metadata.visibility is models.Visibility.hidden
+
+
+# ----------------------------------------------------------------------
+# The book's tier is the default for the resources the build records.
+# ----------------------------------------------------------------------
+def test_recorded_resources_take_the_books_visibility(tmp_path: Path) -> None:
+    """A public book records public resources, so a generated feedstock can publish."""
+    with _recording(_write_recipe(tmp_path, "visibility: public"), tmp_path / "bundle"):
+        bs, _ = setup(version="v1.0.0")
+        with bs.activity(kind="build", code_ref="test") as activity:
+            activity.register(b"data", type="tabular")
+            activity.register_many([RegisterItem(b"batched", type="tabular")])
+            activity.register_external(type="tabular", uri="https://example.invalid/data.csv")
+        bs.recording_sink.record_document(
+            b"<html/>", logical_key="document/build.html", metadata={}
+        )
+        recorded = [r.visibility for r in bs.bundle.manifest.resources]
+
+    assert recorded == ["public", "public", "public", "public"]
+
+
+def test_a_recorded_resource_can_be_narrowed_below_the_book(tmp_path: Path) -> None:
+    """Narrowing one member of a public book is a deliberate per-resource act."""
+    with _recording(_write_recipe(tmp_path, "visibility: public"), tmp_path / "bundle"):
+        bs, _ = setup(version="v1.0.0")
+        with bs.activity(kind="build", code_ref="test") as activity:
+            activity.register(b"open", type="tabular")
+            activity.register(b"embargoed", type="tabular", visibility="hidden")
+        recorded = [r.visibility for r in bs.bundle.manifest.resources]
+
+    assert recorded == ["public", "hidden"]
+
+
+def test_a_hidden_book_still_records_hidden_resources(tmp_path: Path) -> None:
+    """The pre-existing default is unchanged when nothing declares a wider tier."""
+    with _recording(_write_recipe(tmp_path), tmp_path / "bundle"):
+        bs, _ = setup(version="v1.0.0")
+        with bs.activity(kind="build", code_ref="test") as activity:
+            activity.register(b"data", type="tabular")
+        recorded = [r.visibility for r in bs.bundle.manifest.resources]
+
+    assert recorded == ["hidden"]


### PR DESCRIPTION
Registration defaulted to `hidden` on every producer surface, so a recipe declaring `visibility: public` produced a public book whose every resource was hidden. An author could not fix that from the build file either, because two of the four resources are the `build.ipynb` and `build.html` documents the recorder adds itself and the recipe has no field for them.

- `setup` resolves the book tier from the recipe as before. That tier now becomes the default for every resource the build records afterwards, the recorder own documents included.
- `visibility=` on an individual registration still narrows or widens that one resource, so a public book can hold an embargoed member.
- A build that declares nothing still records `hidden`, and the live API surface is unchanged.

Implemented with an `INHERIT` sentinel in a new `_produce/visibility.py`, so an omitted argument is distinguishable from an explicit tier. `RecordingSink.draft_book` seeds the default from the book it drafts.

Fixes the SDK half of climate-resource/copier-bookshelf-dataset#14. The platform half, which lets a book hold members narrower than itself at all, is climate-resource/bookshelf-platform#423.