### PR TITLE
feat: let producers set a book's data dictionary when drafting

### DIFF
--- a/changelog/145.feature.md
+++ b/changelog/145.feature.md
@@ -1,6 +1,7 @@
 Adds `data_dictionary=` to `Bookshelf.draft_book`,
 so a producer can declare what a book's columns mean at the point the book is drafted.
 
-- The dictionary is recorded in the bundle manifest and sent on replay, so it survives a record and replay round trip.
+- The dictionary is recorded in the bundle manifest and sent on replay,
+  so it survives a record and replay round trip.
 - The recording draft handle reports it, matching the live handle.
 - Refreshes the vendored OpenAPI contract and regenerates the model core.

--- a/changelog/145.feature.md
+++ b/changelog/145.feature.md
@@ -1,0 +1,6 @@
+Adds `data_dictionary=` to `Bookshelf.draft_book`,
+so a producer can declare what a book's columns mean at the point the book is drafted.
+
+- The dictionary is recorded in the bundle manifest and sent on replay, so it survives a record and replay round trip.
+- The recording draft handle reports it, matching the live handle.
+- Refreshes the vendored OpenAPI contract and regenerates the model core.

--- a/packages/bookshelf/openapi.json
+++ b/packages/bookshelf/openapi.json
@@ -219,6 +219,56 @@
         }
       }
     },
+    "/agent/identity/claim/preview": {
+      "post": {
+        "tags": [
+          "agent-auth"
+        ],
+        "summary": "Preview Claim",
+        "description": "Report what completing this claim would grant, for the signed-in user.",
+        "operationId": "previewAgentClaim",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClaimPreviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClaimPreviewResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
     "/agent/identity/claim/verify": {
       "post": {
         "tags": [
@@ -585,7 +635,7 @@
           "volumes"
         ],
         "summary": "Create Volume",
-        "description": "Create a new volume.\n\nRequires write permission.",
+        "description": "Create a new volume.\n\nRequires write permission and the bookshelf:volumes:create capability.\nThe capability decision belongs to ``assert_can_create_volume``,\nand is inert without write,\nso granting it to a read-only principal grants nothing.",
         "operationId": "volumesCreateVolume",
         "security": [
           {
@@ -2159,7 +2209,7 @@
           "resources"
         ],
         "summary": "Get Resource Preview",
-        "description": "Get generic preview for tabular/other resources.\n\nReturns paginated rows with column metadata.\nSuitable for displaying data tables in the UI.",
+        "description": "Get generic preview for tabular/other resources.\n\nReturns paginated rows with column metadata.\nSuitable for displaying data tables in the UI.\n\nRepeat `columns` to preview a subset of a wide resource.\nThe projection is pushed into the read, so the columns left out cost nothing.",
         "operationId": "resourcesGetResourcePreview",
         "security": [
           {},
@@ -2213,6 +2263,27 @@
               "title": "Offset"
             },
             "description": "Row offset for pagination"
+          },
+          {
+            "name": "columns",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Columns to return",
+              "title": "Columns"
+            },
+            "description": "Columns to return"
           }
         ],
         "responses": {
@@ -2228,6 +2299,9 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -5278,6 +5352,14 @@
             "title": "Metadata",
             "description": "Free-form metadata blob."
           },
+          "data_dictionary": {
+            "items": {
+              "$ref": "#/components/schemas/DataDictionaryEntry"
+            },
+            "type": "array",
+            "title": "Data Dictionary",
+            "description": "Column descriptions for the book's tabular and timeseries entries."
+          },
           "hash": {
             "anyOf": [
               {
@@ -5395,6 +5477,14 @@
             "type": "object",
             "title": "Metadata",
             "description": "Optional metadata blob copied onto the new book."
+          },
+          "data_dictionary": {
+            "items": {
+              "$ref": "#/components/schemas/DataDictionaryEntry"
+            },
+            "type": "array",
+            "title": "Data Dictionary",
+            "description": "Column descriptions for the book's tabular and timeseries entries. Applied when the draft is created. A request that resumes an existing book through ``bundle_hash`` returns that book unchanged, so use ``PATCH /v1/books/{book_id}`` to revise a draft's dictionary."
           },
           "bundle_hash": {
             "anyOf": [
@@ -6334,6 +6424,83 @@
         "title": "ClaimBlock",
         "description": "RFC 8628-shaped device-code ceremony block."
       },
+      "ClaimGrant": {
+        "properties": {
+          "scope": {
+            "type": "string",
+            "title": "Scope",
+            "description": "The scope string the access token will carry."
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary",
+            "description": "What the scope lets the agent do, in plain words."
+          },
+          "sensitive": {
+            "type": "boolean",
+            "title": "Sensitive",
+            "description": "True for grants that go beyond reading and writing existing data, so the claim page can call them out rather than list them alongside the rest."
+          }
+        },
+        "type": "object",
+        "required": [
+          "scope",
+          "summary",
+          "sensitive"
+        ],
+        "title": "ClaimGrant",
+        "description": "One scope the claim would grant, described for the human approving it."
+      },
+      "ClaimPreviewRequest": {
+        "properties": {
+          "claim_attempt_token": {
+            "type": "string",
+            "title": "Claim Attempt Token",
+            "description": "Attempt token from the verification URL."
+          }
+        },
+        "type": "object",
+        "required": [
+          "claim_attempt_token"
+        ],
+        "title": "ClaimPreviewRequest",
+        "description": "Body of ``POST /agent/identity/claim/preview``."
+      },
+      "ClaimPreviewResponse": {
+        "properties": {
+          "registration_id": {
+            "type": "string",
+            "title": "Registration Id"
+          },
+          "agent_platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Platform",
+            "description": "Platform the agent declared at registration, if any."
+          },
+          "grants": {
+            "items": {
+              "$ref": "#/components/schemas/ClaimGrant"
+            },
+            "type": "array",
+            "title": "Grants",
+            "description": "Scopes the registration will carry once claimed."
+          }
+        },
+        "type": "object",
+        "required": [
+          "registration_id",
+          "grants"
+        ],
+        "title": "ClaimPreviewResponse",
+        "description": "What a claim would grant, shown before the user types the code."
+      },
       "ClaimStartRequest": {
         "properties": {
           "claim_token": {
@@ -6343,6 +6510,7 @@
           },
           "email": {
             "type": "string",
+            "minLength": 3,
             "title": "Email",
             "description": "Email the registration binds to."
           }
@@ -7033,6 +7201,18 @@
             "type": "integer",
             "title": "Expires In",
             "description": "URL expiration time in seconds"
+          },
+          "filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filename",
+            "description": "Name the downloaded bytes should be saved under. Presigned URLs carry it as a Content-Disposition, so a browser uses it without the caller doing anything. Clients that write the bytes themselves should use it too. Absent for external pointers, whose naming the bookshelf does not control."
           }
         },
         "type": "object",
@@ -8534,7 +8714,7 @@
               }
             ],
             "title": "External Uri",
-            "description": "External pointer URI. When set, the item is registered as an external pointer (J3) and ``locations`` may be omitted."
+            "description": "External pointer URI. Must be ``https``. When set, the item is registered as an external pointer (J3) and ``locations`` may be omitted."
           },
           "locations": {
             "items": {
@@ -9108,6 +9288,11 @@
             "type": "string",
             "title": "Type"
           },
+          "tracking_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tracking Id"
+          },
           "format": {
             "anyOf": [
               {
@@ -9168,7 +9353,8 @@
         "required": [
           "id",
           "name",
-          "type"
+          "type",
+          "tracking_id"
         ],
         "title": "ResourceSummary",
         "description": "Resource info for book responses, including download metadata."
@@ -10169,6 +10355,14 @@
             "title": "Resource Types",
             "description": "Unique resource types"
           },
+          "formats": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Formats",
+            "description": "Unique file formats across the readable resources"
+          },
           "total_resources": {
             "type": "integer",
             "title": "Total Resources",
@@ -10193,7 +10387,7 @@
           "updated_at"
         ],
         "title": "VolumeListItem",
-        "description": "Volume response for list endpoints with aggregated fields.\n\nAPI.md specifies that list endpoint returns additional computed fields:\n- latest_version: Most recent version string\n- latest_edition: Highest edition number for latest_version\n- resource_types: Array of unique resource types across all books"
+        "description": "Volume response for list endpoints with aggregated fields.\n\nAPI.md specifies that list endpoint returns additional computed fields:\n- latest_version: Most recent version string\n- latest_edition: Highest edition number for latest_version\n- resource_types: Array of unique resource types across all books\n- formats: Array of unique file formats across all books"
       },
       "VolumeListResponse": {
         "properties": {

--- a/packages/bookshelf/src/bookshelf/_cli/producer.py
+++ b/packages/bookshelf/src/bookshelf/_cli/producer.py
@@ -48,7 +48,7 @@ from bookshelf.publisher import (
     replay_bundle_sync,
     run_record,
 )
-from bookshelf.publisher.bundle import BundleBook
+from bookshelf.publisher.bundle import BundleBook, book_data_dictionary
 
 _RECORD_REQUIREMENTS = ("papermill", "nbconvert")
 _PAGE_SIZE = 100
@@ -303,6 +303,10 @@ def publish(
                 license=framing.license,
                 visibility=framing.visibility,
                 metadata=framing.metadata,
+                # This draft is keyed on the bundle hash, so the replay below
+                # resumes it rather than reapplying the framing. The dictionary
+                # has to travel on this call or it never reaches the book.
+                data_dictionary=book_data_dictionary(framing),
                 bundle_hash=bundle_hash,
             )
             # Drafting is the only way to learn whether the edition already exists,

--- a/packages/bookshelf/src/bookshelf/_generated/models.py
+++ b/packages/bookshelf/src/bookshelf/_generated/models.py
@@ -309,11 +309,51 @@ class ClaimBlock(BaseModel):
     ]
 
 
+class ClaimGrant(BaseModel):
+    scope: Annotated[
+        str, Field(description="The scope string the access token will carry.", title="Scope")
+    ]
+    summary: Annotated[
+        str, Field(description="What the scope lets the agent do, in plain words.", title="Summary")
+    ]
+    sensitive: Annotated[
+        bool,
+        Field(
+            description="True for grants that go beyond reading and writing existing data, so the claim page can call them out rather than list them alongside the rest.",
+            title="Sensitive",
+        ),
+    ]
+
+
+class ClaimPreviewRequest(BaseModel):
+    claim_attempt_token: Annotated[
+        str,
+        Field(description="Attempt token from the verification URL.", title="Claim Attempt Token"),
+    ]
+
+
+class ClaimPreviewResponse(BaseModel):
+    registration_id: Annotated[str, Field(title="Registration Id")]
+    agent_platform: Annotated[
+        str | None,
+        Field(
+            description="Platform the agent declared at registration, if any.",
+            title="Agent Platform",
+        ),
+    ] = None
+    grants: Annotated[
+        list[ClaimGrant],
+        Field(description="Scopes the registration will carry once claimed.", title="Grants"),
+    ]
+
+
 class ClaimStartRequest(BaseModel):
     claim_token: Annotated[
         str, Field(description="The registration's claim token.", title="Claim Token")
     ]
-    email: Annotated[str, Field(description="Email the registration binds to.", title="Email")]
+    email: Annotated[
+        str, Field(description="Email the registration binds to.", min_length=3, title="Email")
+    ]
 
 
 class ClaimStartResponse(BaseModel):
@@ -568,6 +608,13 @@ class DownloadResponse(BaseModel):
     expires_in: Annotated[
         int, Field(description="URL expiration time in seconds", title="Expires In")
     ]
+    filename: Annotated[
+        str | None,
+        Field(
+            description="Name the downloaded bytes should be saved under. Presigned URLs carry it as a Content-Disposition, so a browser uses it without the caller doing anything. Clients that write the bytes themselves should use it too. Absent for external pointers, whose naming the bookshelf does not control.",
+            title="Filename",
+        ),
+    ] = None
 
 
 class DownstreamEntry(BaseModel):
@@ -887,6 +934,7 @@ class ResourceSummary(BaseModel):
     id: Annotated[str, Field(title="Id")]
     name: Annotated[str, Field(title="Name")]
     type: Annotated[str, Field(title="Type")]
+    tracking_id: Annotated[UUID, Field(title="Tracking Id")]
     format: Annotated[str | None, Field(title="Format")] = None
     size_bytes: Annotated[int | None, Field(title="Size Bytes")] = None
     hash: Annotated[str | None, Field(title="Hash")] = None
@@ -1315,6 +1363,13 @@ class BookDraftRequest(BaseModel):
     metadata: Annotated[
         dict[str, Any] | None,
         Field(description="Optional metadata blob copied onto the new book.", title="Metadata"),
+    ] = None
+    data_dictionary: Annotated[
+        list[DataDictionaryEntry] | None,
+        Field(
+            description="Column descriptions for the book's tabular and timeseries entries. Applied when the draft is created. A request that resumes an existing book through ``bundle_hash`` returns that book unchanged, so use ``PATCH /v1/books/{book_id}`` to revise a draft's dictionary.",
+            title="Data Dictionary",
+        ),
     ] = None
     bundle_hash: Annotated[
         BundleHash | None,
@@ -1818,7 +1873,7 @@ class RegisterResourceItem(BaseModel):
     external_uri: Annotated[
         str | None,
         Field(
-            description="External pointer URI. When set, the item is registered as an external pointer (J3) and ``locations`` may be omitted.",
+            description="External pointer URI. Must be ``https``. When set, the item is registered as an external pointer (J3) and ``locations`` may be omitted.",
             title="External Uri",
         ),
     ] = None
@@ -2102,6 +2157,10 @@ class VolumeListItem(BaseModel):
     resource_types: Annotated[
         list[str] | None, Field(description="Unique resource types", title="Resource Types")
     ] = None
+    formats: Annotated[
+        list[str] | None,
+        Field(description="Unique file formats across the readable resources", title="Formats"),
+    ] = None
     total_resources: Annotated[
         int | None,
         Field(description="Resources across the readable books", title="Total Resources"),
@@ -2192,6 +2251,13 @@ class BookDetail(BaseModel):
     ] = None
     metadata: Annotated[
         dict[str, Any] | None, Field(description="Free-form metadata blob.", title="Metadata")
+    ] = None
+    data_dictionary: Annotated[
+        list[DataDictionaryEntry] | None,
+        Field(
+            description="Column descriptions for the book's tabular and timeseries entries.",
+            title="Data Dictionary",
+        ),
     ] = None
     hash: Annotated[
         str | None, Field(description="Bundle SHA256 hash; only set after publish.", title="Hash")

--- a/packages/bookshelf/src/bookshelf/_produce/facade.py
+++ b/packages/bookshelf/src/bookshelf/_produce/facade.py
@@ -127,6 +127,7 @@ class LiveSink:
         license: str | None = None,
         visibility: str | models.Visibility = models.Visibility.hidden,
         metadata: Mapping[str, Any] | None = None,
+        data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
         bundle_hash: str | None = None,
     ) -> DraftBook:
         """Create a mutable draft whose membership changes remain intentional calls."""
@@ -141,6 +142,7 @@ class LiveSink:
                 license=models.License(root=license) if license is not None else None,
                 visibility=_visibility(visibility),
                 metadata=dict(metadata or {}),
+                data_dictionary=list(data_dictionary or []),
                 bundle_hash=(
                     models.BundleHash(root=bundle_hash) if bundle_hash is not None else None
                 ),
@@ -236,6 +238,7 @@ class AsyncLiveSink:
         license: str | None = None,
         visibility: str | models.Visibility = models.Visibility.hidden,
         metadata: Mapping[str, Any] | None = None,
+        data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
         bundle_hash: str | None = None,
     ) -> AsyncDraftBook:
         """Create an asynchronous mutable draft book handle."""
@@ -250,6 +253,7 @@ class AsyncLiveSink:
                 license=models.License(root=license) if license is not None else None,
                 visibility=_visibility(visibility),
                 metadata=dict(metadata or {}),
+                data_dictionary=list(data_dictionary or []),
                 bundle_hash=(
                     models.BundleHash(root=bundle_hash) if bundle_hash is not None else None
                 ),
@@ -296,6 +300,7 @@ class ProduceSink(Protocol):
         license: str | None = None,
         visibility: str | models.Visibility = models.Visibility.hidden,
         metadata: Mapping[str, Any] | None = None,
+        data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
         bundle_hash: str | None = None,
     ) -> DraftBook: ...
 
@@ -338,6 +343,7 @@ class AsyncProduceSink(Protocol):
         license: str | None = None,
         visibility: str | models.Visibility = models.Visibility.hidden,
         metadata: Mapping[str, Any] | None = None,
+        data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
         bundle_hash: str | None = None,
     ) -> AsyncDraftBook: ...
 
@@ -403,9 +409,14 @@ class ProduceFacade:
         license: str | None = None,
         visibility: str | models.Visibility = models.Visibility.hidden,
         metadata: Mapping[str, Any] | None = None,
+        data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
         bundle_hash: str | None = None,
     ) -> DraftBook:
-        """Create a draft through the active sink."""
+        """Create a draft through the active sink.
+
+        ``data_dictionary=`` describes the columns of the book's tabular and
+        timeseries entries. It stays editable while the book is a draft.
+        """
         return self._produce_sink.draft_book(
             volume,
             version=version,
@@ -414,6 +425,7 @@ class ProduceFacade:
             license=license,
             visibility=visibility,
             metadata=metadata,
+            data_dictionary=data_dictionary,
             bundle_hash=bundle_hash,
         )
 
@@ -479,9 +491,14 @@ class AsyncProduceFacade:
         license: str | None = None,
         visibility: str | models.Visibility = models.Visibility.hidden,
         metadata: Mapping[str, Any] | None = None,
+        data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
         bundle_hash: str | None = None,
     ) -> AsyncDraftBook:
-        """Create a draft through the active sink."""
+        """Create a draft through the active sink.
+
+        ``data_dictionary=`` describes the columns of the book's tabular and
+        timeseries entries. It stays editable while the book is a draft.
+        """
         return await self._produce_sink.draft_book(
             volume,
             version=version,
@@ -490,6 +507,7 @@ class AsyncProduceFacade:
             license=license,
             visibility=visibility,
             metadata=metadata,
+            data_dictionary=data_dictionary,
             bundle_hash=bundle_hash,
         )
 

--- a/packages/bookshelf/src/bookshelf/_produce/facade.py
+++ b/packages/bookshelf/src/bookshelf/_produce/facade.py
@@ -415,7 +415,9 @@ class ProduceFacade:
         """Create a draft through the active sink.
 
         ``data_dictionary=`` describes the columns of the book's tabular and
-        timeseries entries. It stays editable while the book is a draft.
+        timeseries entries. It is applied when the draft is created, so a call
+        that resumes an existing book through ``bundle_hash`` leaves the stored
+        dictionary untouched.
         """
         return self._produce_sink.draft_book(
             volume,
@@ -497,7 +499,9 @@ class AsyncProduceFacade:
         """Create a draft through the active sink.
 
         ``data_dictionary=`` describes the columns of the book's tabular and
-        timeseries entries. It stays editable while the book is a draft.
+        timeseries entries. It is applied when the draft is created, so a call
+        that resumes an existing book through ``bundle_hash`` leaves the stored
+        dictionary untouched.
         """
         return await self._produce_sink.draft_book(
             volume,

--- a/packages/bookshelf/src/bookshelf/publisher/bundle.py
+++ b/packages/bookshelf/src/bookshelf/publisher/bundle.py
@@ -307,6 +307,7 @@ class BundleBook(BaseModel):
     description: str | None = None
     citation_doi: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    data_dictionary: list[dict[str, Any]] = Field(default_factory=list)
     entries: list[BundleBookEntry] = Field(default_factory=list)
     published: bool = False
 

--- a/packages/bookshelf/src/bookshelf/publisher/bundle.py
+++ b/packages/bookshelf/src/bookshelf/publisher/bundle.py
@@ -79,6 +79,7 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from bookshelf._core.hashing import canonical_json_bytes, sha256_hex
+from bookshelf._generated import models
 from bookshelf.publisher.lock import _dump_sorted_yaml
 
 BUNDLE_SCHEMA_VERSION = "1.0"
@@ -385,6 +386,11 @@ def resource_filename(hash_: str, type_: str) -> str:
     hex_digest = _sha256_hex(hash_)
     extension = "parquet" if type_ in _PARQUET_TYPES else "bin"
     return f"{hex_digest}.{extension}"
+
+
+def book_data_dictionary(book: BundleBook) -> list[models.DataDictionaryEntry]:
+    """Return a recorded book's data dictionary as validated entries."""
+    return [models.DataDictionaryEntry.model_validate(entry) for entry in book.data_dictionary]
 
 
 def compute_book_bundle_hash(manifest: BundleManifest) -> str:

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -389,6 +389,7 @@ class RecordedDraftBook(DraftBook):
         description: str | None,
         citation_doi: str | None,
         metadata: Mapping[str, Any] | None,
+        data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
     ) -> None:
         self._bundle = bundle
         super().__init__(
@@ -405,6 +406,7 @@ class RecordedDraftBook(DraftBook):
                 license=license,
                 citation_doi=citation_doi,
                 metadata=dict(metadata or {}),
+                data_dictionary=list(data_dictionary or []),
             ),
         )
 
@@ -500,6 +502,7 @@ class RecordingSink:
         license: str | None = None,
         visibility: VisibilityInput = INHERIT,
         metadata: Mapping[str, Any] | None = None,
+        data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
         bundle_hash: str | None = None,
     ) -> RecordedDraftBook:
         """Record pre-edition book framing and return its local handle.
@@ -512,6 +515,7 @@ class RecordingSink:
             raise ValueError("recorded books require an explicit license")
         book_visibility = _visibility(visibility, self.default_visibility)
         self.default_visibility = book_visibility
+        entries = list(data_dictionary or [])
         self.bundle.set_book(
             BundleBook(
                 volume=volume,
@@ -522,6 +526,7 @@ class RecordingSink:
                 description=description,
                 citation_doi=citation_doi,
                 metadata=dict(metadata or {}),
+                data_dictionary=[entry.model_dump(mode="json") for entry in entries],
             )
         )
         return RecordedDraftBook(
@@ -534,6 +539,7 @@ class RecordingSink:
             description=description,
             citation_doi=citation_doi,
             metadata=metadata,
+            data_dictionary=entries,
         )
 
     def register_external(

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -515,7 +515,7 @@ class RecordingSink:
             raise ValueError("recorded books require an explicit license")
         book_visibility = _visibility(visibility, self.default_visibility)
         self.default_visibility = book_visibility
-        entries = list(data_dictionary or [])
+        dictionary_entries = list(data_dictionary or [])
         self.bundle.set_book(
             BundleBook(
                 volume=volume,
@@ -526,7 +526,7 @@ class RecordingSink:
                 description=description,
                 citation_doi=citation_doi,
                 metadata=dict(metadata or {}),
-                data_dictionary=[entry.model_dump(mode="json") for entry in entries],
+                data_dictionary=[entry.model_dump(mode="json") for entry in dictionary_entries],
             )
         )
         return RecordedDraftBook(
@@ -539,7 +539,7 @@ class RecordingSink:
             description=description,
             citation_doi=citation_doi,
             metadata=metadata,
-            data_dictionary=entries,
+            data_dictionary=dictionary_entries,
         )
 
     def register_external(

--- a/packages/bookshelf/src/bookshelf/publisher/replay.py
+++ b/packages/bookshelf/src/bookshelf/publisher/replay.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping
 from pathlib import Path
 from uuid import UUID
 
-from bookshelf._generated import models
 from bookshelf._produce.books import AsyncDraftBook, DraftBook
 from bookshelf._produce.resources import AsyncResource, Resource
 from bookshelf._produce.types import Used, UsedInput
@@ -15,6 +14,7 @@ from bookshelf.publisher.bundle import (
     Bundle,
     BundleResource,
     BundleUsedRef,
+    book_data_dictionary,
     compute_book_bundle_hash,
 )
 
@@ -59,9 +59,7 @@ async def replay_bundle(
         visibility=book.visibility,
         license=book.license,
         metadata=book.metadata,
-        data_dictionary=[
-            models.DataDictionaryEntry.model_validate(entry) for entry in book.data_dictionary
-        ],
+        data_dictionary=book_data_dictionary(book),
         bundle_hash=compute_book_bundle_hash(manifest),
     )
     if draft.status == "published":
@@ -163,9 +161,7 @@ def replay_bundle_sync(
         visibility=book.visibility,
         license=book.license,
         metadata=book.metadata,
-        data_dictionary=[
-            models.DataDictionaryEntry.model_validate(entry) for entry in book.data_dictionary
-        ],
+        data_dictionary=book_data_dictionary(book),
         bundle_hash=compute_book_bundle_hash(manifest),
     )
     if draft.status == "published":

--- a/packages/bookshelf/src/bookshelf/publisher/replay.py
+++ b/packages/bookshelf/src/bookshelf/publisher/replay.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from uuid import UUID
 
+from bookshelf._generated import models
 from bookshelf._produce.books import AsyncDraftBook, DraftBook
 from bookshelf._produce.resources import AsyncResource, Resource
 from bookshelf._produce.types import Used, UsedInput
@@ -58,6 +59,9 @@ async def replay_bundle(
         visibility=book.visibility,
         license=book.license,
         metadata=book.metadata,
+        data_dictionary=[
+            models.DataDictionaryEntry.model_validate(entry) for entry in book.data_dictionary
+        ],
         bundle_hash=compute_book_bundle_hash(manifest),
     )
     if draft.status == "published":
@@ -159,6 +163,9 @@ def replay_bundle_sync(
         visibility=book.visibility,
         license=book.license,
         metadata=book.metadata,
+        data_dictionary=[
+            models.DataDictionaryEntry.model_validate(entry) for entry in book.data_dictionary
+        ],
         bundle_hash=compute_book_bundle_hash(manifest),
     )
     if draft.status == "published":

--- a/packages/bookshelf/tests/test_cli_producer.py
+++ b/packages/bookshelf/tests/test_cli_producer.py
@@ -683,3 +683,40 @@ def test_tracking_ids_round_trip_as_uuids(tmp_path: Path) -> None:
     reloaded = Bundle.read(bundle.root)
 
     assert isinstance(reloaded.manifest.resources[0].tracking_id, UUID)
+
+
+def test_publish_sends_the_recorded_data_dictionary_on_the_draft(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dictionary has to ride on the CLI's own draft call.
+
+    That draft is keyed on the bundle hash, so the replay underneath resumes it
+    and never reapplies the framing.
+    """
+    bundle = Bundle(tmp_path / "bundle")
+    bundle.set_book(
+        BundleBook(
+            volume="example",
+            version="v1.0.0",
+            visibility="public",
+            license="MIT",
+            data_dictionary=[{"name": "region", "type": "string", "role": "dimension"}],
+        )
+    )
+    data = b"payload"
+    resource = bundle.add_resource(
+        data=data, hash_=sha256_hex(data), type_="document", tracking_id=uuid4()
+    )
+    bundle.add_book_entry(name_in_book="entry-0", tracking_id=resource.tracking_id)
+    bundle.mark_book_published()
+    bundle.write()
+
+    client = _FakeClient(status="draft")
+    _patch_publish(monkeypatch, client, edition=2)
+
+    result = runner.invoke(app, ["publish", str(bundle.root), "--json"])
+
+    assert result.exit_code == EXIT_OK
+    sent = client.draft_kwargs["data_dictionary"]
+    assert [entry.name for entry in sent] == ["region"]
+    assert sent[0].role == "dimension"

--- a/packages/bookshelf/tests/test_data_dictionary.py
+++ b/packages/bookshelf/tests/test_data_dictionary.py
@@ -1,0 +1,85 @@
+"""The data dictionary a producer declares survives recording and replay."""
+
+from pathlib import Path
+
+from bookshelf._generated import models
+from bookshelf.publisher import RecordingBookshelf
+from bookshelf.publisher.bundle import Bundle, BundleBook
+from bookshelf.publisher.replay import replay_bundle_sync
+
+
+class _FakeDraft:
+    status = "draft"
+
+    def attach(self, resource, *, name_in_book: str) -> None:  # pragma: no cover - unused
+        del resource, name_in_book
+
+    def publish(self) -> None:  # pragma: no cover - unused
+        pass
+
+
+class _FakeBookshelf:
+    """Captures the keyword arguments replay sends to ``draft_book``."""
+
+    def __init__(self) -> None:
+        self.draft_kwargs: dict = {}
+
+    def draft_book(self, *_args, **kwargs) -> _FakeDraft:
+        self.draft_kwargs = kwargs
+        return _FakeDraft()
+
+
+def test_recording_carries_the_data_dictionary_into_the_bundle(tmp_path: Path) -> None:
+    """A dictionary passed at draft time is recorded in the manifest."""
+    bundle = Bundle(tmp_path / "bundle")
+
+    with RecordingBookshelf(bundle) as recording:
+        book = recording.draft_book(
+            "example",
+            version="v1.0.0",
+            license="MIT",
+            data_dictionary=[
+                models.DataDictionaryEntry(name="region", role="dimension"),
+                models.DataDictionaryEntry(name="value", type="number", role="measure"),
+            ],
+        )
+
+    assert bundle.manifest.book is not None
+    recorded = bundle.manifest.book.data_dictionary
+    assert [entry["name"] for entry in recorded] == ["region", "value"]
+    assert recorded[1]["role"] == "measure"
+
+    # The recording handle reports the same dictionary as a live draft handle.
+    assert [entry.name for entry in book.metadata.data_dictionary] == ["region", "value"]
+
+
+def test_bundle_without_a_data_dictionary_stays_empty(tmp_path: Path) -> None:
+    """The field is additive: an untouched recording records an empty list."""
+    bundle = Bundle(tmp_path / "bundle")
+
+    with RecordingBookshelf(bundle) as recording:
+        recording.draft_book("example", version="v1.0.0", license="MIT")
+
+    assert bundle.manifest.book is not None
+    assert bundle.manifest.book.data_dictionary == []
+
+
+def test_replay_sends_the_recorded_data_dictionary(tmp_path: Path) -> None:
+    """Replay forwards the recorded dictionary, so it survives the round trip."""
+    bundle = Bundle(tmp_path / "bundle")
+    bundle.set_book(
+        BundleBook(
+            volume="example",
+            version="v1.0.0",
+            visibility="hidden",
+            license="MIT",
+            data_dictionary=[{"name": "region", "type": "string", "role": "dimension"}],
+        )
+    )
+
+    client = _FakeBookshelf()
+    replay_bundle_sync(bundle, client)
+
+    sent = client.draft_kwargs["data_dictionary"]
+    assert [entry.name for entry in sent] == ["region"]
+    assert sent[0].role == "dimension"


### PR DESCRIPTION
Ports the data-dictionary write path from bookshelf-platform, where it landed as https://github.com/climate-resource/bookshelf-platform/pull/425 (merged).

Targets `feat/adopt-bookshelf-sdk` rather than `main`, because the V2 SDK only exists on that branch. On `main`, `packages/bookshelf` is still the V1 library.

## Why

The SDK had no way to declare what a book's columns mean. `draft_book()` took no dictionary, and there is no edit method, so a producer could publish a book and say nothing about its schema. This was found while spiking whether a real NDC Analysis Portal release could be published through the platform: the release parquet is 414,072 rows by 134 columns, 13 index columns plus 121 wide year columns, which is exactly the shape a data dictionary exists to describe.

## Changes

- Refreshes the vendored `openapi.json` and regenerates the model core, per the documented refresh workflow in the package README.
- Adds `data_dictionary=` to `draft_book()` across both facades, both live sinks, and both protocols.
- Records it in the bundle manifest (`BundleBook.data_dictionary`) and sends it on replay, so a recorded dictionary survives the round trip rather than silently vanishing.
- Reports it on `RecordedDraftBook`, so a recording handle shows the same dictionary as a live draft handle.

## Compatibility

- `BundleBook` uses `extra="ignore"`, so bundles recorded before this change load unchanged and record an empty dictionary.
- The field sits outside `compute_book_bundle_hash`, which seals only license, members and visibility, so existing bundle hashes are unaffected and replay still converges on one edition.

## Snapshot refresh brings one unrelated addition

Refreshing the vendored contract also picks up the platform's `ClaimGrant`, `ClaimPreviewRequest` and `ClaimPreviewResponse` schemas. They are additive and unrelated to this change, but the documented workflow is to refresh the snapshot wholesale rather than hand-edit it, so they come along.

Note the refreshed snapshot includes the platform change from #425. That is merged on the platform's `main`.

## Tests

Three new tests in `packages/bookshelf/tests/test_data_dictionary.py`: the bundle carries the dictionary and the recording handle reports it, an untouched recording stays empty, and replay forwards it.

Package suite: 425 passed. `pre-commit` clean on the changed files. `mypy` reports the same 7 pre-existing errors as the base branch, none in the ported code.

## Known gap, not fixed here

Replay only ever calls `draft_book`, and `BookWriter.draft` returns an existing book unchanged when `bundle_hash` matches. So a producer who edits a dictionary and re-replays resumes the existing draft and keeps the stale dictionary. Phase 3 of the data-dictionary design closes this by sealing the dictionary into the bundle hash, which would make an edited dictionary mint a new edition.
