### PR TITLE
feat: let a build file declare its data dictionary through setup

### DIFF
--- a/changelog/146.feature.md
+++ b/changelog/146.feature.md
@@ -1,0 +1,3 @@
+Adds `data_dictionary=` to `bookshelf.setup`,
+so a standalone build file can declare what its columns mean.
+The dictionary is forwarded on both the recorded and the direct draft.

--- a/packages/bookshelf/src/bookshelf/_produce/facade.py
+++ b/packages/bookshelf/src/bookshelf/_produce/facade.py
@@ -416,7 +416,8 @@ class ProduceFacade:
 
         ``data_dictionary=`` describes the columns of the book's tabular and timeseries entries.
         It is applied when the draft is created,
-        so a call that resumes an existing book through ``bundle_hash`` leaves the stored dictionary untouched.
+        so a call that resumes an existing book through ``bundle_hash``
+        leaves the stored dictionary untouched.
         """
         return self._produce_sink.draft_book(
             volume,

--- a/packages/bookshelf/src/bookshelf/_produce/facade.py
+++ b/packages/bookshelf/src/bookshelf/_produce/facade.py
@@ -414,10 +414,9 @@ class ProduceFacade:
     ) -> DraftBook:
         """Create a draft through the active sink.
 
-        ``data_dictionary=`` describes the columns of the book's tabular and
-        timeseries entries. It is applied when the draft is created, so a call
-        that resumes an existing book through ``bundle_hash`` leaves the stored
-        dictionary untouched.
+        ``data_dictionary=`` describes the columns of the book's tabular and timeseries entries.
+        It is applied when the draft is created,
+        so a call that resumes an existing book through ``bundle_hash`` leaves the stored dictionary untouched.
         """
         return self._produce_sink.draft_book(
             volume,

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -697,8 +697,6 @@ def setup(
     Pass ``visibility=`` on an individual registration to narrow that one resource.
 
     ``data_dictionary=`` describes the columns of the book's tabular and timeseries entries.
-    It belongs in the build file rather than the recipe,
-    because the columns follow the frame the build assembles.
     """
     book: DraftBook | RecordedDraftBook
     context = _ACTIVE_RECORDING.get()

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -679,6 +679,7 @@ def setup(
     version: str,
     visibility: str | models.Visibility | None = None,
     license: str | None = None,
+    data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
     collection: str | None = None,
     base_url: str | None = None,
     auth: AuthInput = UNSET,
@@ -694,6 +695,10 @@ def setup(
     The resolved tier is also the default for every resource the build records,
     including the notebook and HTML documents the recorder adds itself.
     Pass ``visibility=`` on an individual registration to narrow that one resource.
+
+    ``data_dictionary=`` describes the columns of the book's tabular and timeseries entries.
+    It belongs in the build file rather than the recipe,
+    because the columns follow the frame the build assembles.
     """
     book: DraftBook | RecordedDraftBook
     context = _ACTIVE_RECORDING.get()
@@ -722,6 +727,7 @@ def setup(
                 else context.recipe.visibility or models.Visibility.hidden
             ),
             license=license or context.recipe.license,
+            data_dictionary=data_dictionary,
         )
         if not isinstance(book, RecordedDraftBook):
             raise TypeError("recording sink returned a live draft book")
@@ -741,6 +747,7 @@ def setup(
         version=version,
         visibility=visibility if visibility is not None else models.Visibility.hidden,
         license=license,
+        data_dictionary=data_dictionary,
     )
     return SetupResult(bs, book)
 

--- a/packages/bookshelf/tests/test_record_recipe.py
+++ b/packages/bookshelf/tests/test_record_recipe.py
@@ -4,6 +4,7 @@ import textwrap
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -172,3 +173,54 @@ def test_a_hidden_book_still_records_hidden_resources(tmp_path: Path) -> None:
         recorded = [r.visibility for r in bs.bundle.manifest.resources]
 
     assert recorded == ["hidden"]
+
+
+# ----------------------------------------------------------------------
+# The build file declares the columns of the data it assembles.
+# ----------------------------------------------------------------------
+def test_a_recorded_build_declares_its_data_dictionary(tmp_path: Path) -> None:
+    with _recording(_write_recipe(tmp_path), tmp_path / "bundle"):
+        bs, _ = setup(
+            version="v1.0.0",
+            data_dictionary=[
+                models.DataDictionaryEntry(name="region", role=models.Role.dimension),
+                models.DataDictionaryEntry(name="value", type="number", role=models.Role.measure),
+            ],
+        )
+        book = bs.bundle.manifest.book
+
+    assert book is not None
+    assert [entry["name"] for entry in book.data_dictionary] == ["region", "value"]
+    assert book.data_dictionary[1]["role"] == "measure"
+
+
+def test_a_build_that_declares_no_columns_records_an_empty_dictionary(tmp_path: Path) -> None:
+    with _recording(_write_recipe(tmp_path), tmp_path / "bundle"):
+        bs, _ = setup(version="v1.0.0")
+        book = bs.bundle.manifest.book
+
+    assert book is not None
+    assert book.data_dictionary == []
+
+
+def test_direct_setup_sends_the_data_dictionary_to_the_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The no-recording branch drafts against a live client, so it must forward it too."""
+    captured: dict[str, Any] = {}
+
+    class _FakeBookshelf:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            del args, kwargs
+
+        def draft_book(self, *args: Any, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return object()
+
+    monkeypatch.setattr("bookshelf.publisher.record.Bookshelf", _FakeBookshelf)
+
+    setup(
+        version="v1.0.0",
+        collection="my-dataset",
+        data_dictionary=[models.DataDictionaryEntry(name="region", role=models.Role.dimension)],
+    )
+
+    assert [entry.name for entry in captured["data_dictionary"]] == ["region"]


### PR DESCRIPTION
Adds `data_dictionary=` to `bookshelf.setup`, so a standalone build file can declare what its columns mean.

- Forwards the dictionary on both branches of `setup`: the recorded draft and the direct one.
- Without this the keyword was unreachable from a build file, which is the only place a producer writes one. It could only be passed by calling `draft_book` by hand.
- The dictionary stays out of `bookshelf.yaml` on purpose. The recipe holds run-invariant framing, and the columns follow the frame the build assembles.

Builds on https://github.com/climate-resource/bookshelf/pull/145, so review that first. The base will move to `feat/adopt-bookshelf-sdk` once 145 merges.
