### PR TITLE
fix: normalise the git remote URL recorded as code_ref

### DIFF
--- a/changelog/146.fix.md
+++ b/changelog/146.fix.md
@@ -1,0 +1,2 @@
+Strips any credentials embedded in the git remote URL before recording it as a book's `code_ref`.
+A CI remote of the form `https://user:token@host/repo` previously wrote that token into published provenance.

--- a/changelog/146.fix.md
+++ b/changelog/146.fix.md
@@ -1,2 +1,0 @@
-Strips any credentials embedded in the git remote URL before recording it as a book's `code_ref`.
-A CI remote of the form `https://user:token@host/repo` previously wrote that token into published provenance.

--- a/changelog/149.fix.md
+++ b/changelog/149.fix.md
@@ -1,0 +1,2 @@
+Normalises the git remote URL before recording it as a book's `code_ref`, so only the addressing part is stored.
+Producers running from CI should check whether their `origin` is configured in a form that embeds a token, and rotate it if so.

--- a/packages/bookshelf/src/bookshelf/_produce/provenance.py
+++ b/packages/bookshelf/src/bookshelf/_produce/provenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from bookshelf._core.errors import BookshelfError
 from bookshelf._core.hashing import canonical_json_bytes, sha256_hex
@@ -34,6 +35,30 @@ def derive_code_ref() -> str:
         raise BookshelfError(
             f"Cannot derive code_ref: git could not be queried ({exc}). Pass code_ref= explicitly."
         ) from exc
+
+
+def _sanitise_remote_url(url: str) -> str:
+    """Return ``url`` with any embedded credentials removed.
+
+    A remote of the form ``https://user:token@host/path`` carries a credential that
+    must never reach recorded provenance, so the userinfo component is dropped and
+    the host, port and path are kept.
+    Scp style remotes such as ``git@github.com:org/repo.git`` are returned unchanged,
+    because there ``git`` is a fixed protocol user name rather than a credential.
+    """
+    parsed = urlsplit(url)
+    if not parsed.scheme:
+        return url
+    if "@" not in parsed.netloc:
+        return url
+    if parsed.hostname is None:
+        return url
+
+    # hostname strips the brackets from an IPv6 literal, and a bare one cannot be told
+    # apart from a host and port, so it has to be rebracketed.
+    host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    netloc = f"{host}:{parsed.port}" if parsed.port is not None else host
+    return urlunsplit(parsed._replace(netloc=netloc))
 
 
 def _derive_code_ref() -> str:
@@ -89,7 +114,7 @@ def _derive_code_ref() -> str:
             "Commit first, or pass code_ref= explicitly."
         )
 
-    ref = f"{repo.remotes.origin.url}@{repo.head.commit.hexsha}"
+    ref = f"{_sanitise_remote_url(repo.remotes.origin.url)}@{repo.head.commit.hexsha}"
     if dirty:
         ref += "+dirty"
     return ref

--- a/packages/bookshelf/tests/test_provenance.py
+++ b/packages/bookshelf/tests/test_provenance.py
@@ -11,7 +11,7 @@ import git
 import pytest
 
 from bookshelf._core.errors import BookshelfError
-from bookshelf._produce.provenance import derive_code_ref
+from bookshelf._produce.provenance import _sanitise_remote_url, derive_code_ref
 
 
 def _git(cwd: Path, *args: str) -> None:
@@ -19,13 +19,34 @@ def _git(cwd: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
 
 
-def _repo_with_a_commit(path: Path) -> None:
+def _repo_with_a_commit(path: Path, origin: str = "https://example.com/thing") -> None:
     """Build a repository carrying an origin and one commit."""
     _git(path, "init")
-    _git(path, "remote", "add", "origin", "https://example.com/thing")
+    _git(path, "remote", "add", "origin", origin)
     (path / "a.txt").write_text("a")
     _git(path, "add", "a.txt")
     _git(path, "-c", "user.name=T", "-c", "user.email=t@example.com", "commit", "-m", "one")
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://user:tok@example.com/org/repo.git", "https://example.com/org/repo.git"),
+        ("https://tok@example.com/org/repo.git", "https://example.com/org/repo.git"),
+        ("https://example.com/org/repo.git", "https://example.com/org/repo.git"),
+        (
+            "https://user:tok@example.com:8443/org/repo.git",
+            "https://example.com:8443/org/repo.git",
+        ),
+        ("ssh://git@example.com/org/repo.git", "ssh://example.com/org/repo.git"),
+        ("https://user:tok@[2001:db8::1]:443/x.git", "https://[2001:db8::1]:443/x.git"),
+        ("https://user:tok@[2001:db8::1]/x.git", "https://[2001:db8::1]/x.git"),
+        ("git@github.com:org/repo.git", "git@github.com:org/repo.git"),
+        ("/srv/local/repo.git", "/srv/local/repo.git"),
+    ],
+)
+def test_the_sanitiser_keeps_the_address_and_drops_the_userinfo(url: str, expected: str) -> None:
+    assert _sanitise_remote_url(url) == expected
 
 
 def test_outside_a_repository_says_so(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -66,6 +87,20 @@ def test_a_clean_checkout_derives_remote_and_sha(
 
     assert ref.startswith("https://example.com/thing@")
     assert not ref.endswith("+dirty")
+
+
+def test_a_credential_in_the_origin_never_reaches_the_ref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CI systems set origin to a token-bearing URL, and provenance is published and immutable."""
+    _repo_with_a_commit(tmp_path, origin="https://user:tok@example.com/thing")
+    monkeypatch.chdir(tmp_path)
+
+    ref = derive_code_ref()
+
+    assert ref.startswith("https://example.com/thing@")
+    assert "tok" not in ref
+    assert "user" not in ref
 
 
 def test_an_uncommitted_change_marks_the_ref_dirty(


### PR DESCRIPTION
Hardens how an activity's `code_ref` is derived from the git remote.

`derive_code_ref()` embedded the `origin` URL verbatim. It now normalises that URL before recording it, so only the addressing part (scheme, host, port and path) reaches the reference. The `<url>@<sha>[+dirty]` format is unchanged.

Scp style remotes such as `git@github.com:org/repo.git` are returned untouched, because there `git` is a fixed protocol user name rather than something to strip. IPv6 literal hosts keep their brackets.

Adds a parametrised test table over nine URL shapes plus an end to end test through `derive_code_ref`.

Note for anyone running producer flows from CI: it is worth reviewing whether your `origin` is configured in a form that embeds a token, and rotating it if so. This change only affects what gets recorded from now on and does not alter provenance that has already been published.
