### PR TITLE
fix: harden the credential store write path

### DIFF
--- a/changelog/147.fix.md
+++ b/changelog/147.fix.md
@@ -1,0 +1,4 @@
+Stops copying access tokens, refresh tokens and identity assertions into `credentials.json` when the OS keychain accepts them.
+The file copy is now written only when the keychain is unavailable or cannot serve the secret back.
+
+Writes the credential store atomically, so an interrupted write can no longer truncate the file and appear as a logout from every deployment.

--- a/changelog/147.fix.md
+++ b/changelog/147.fix.md
@@ -1,4 +1,0 @@
-Stops copying access tokens, refresh tokens and identity assertions into `credentials.json` when the OS keychain accepts them.
-The file copy is now written only when the keychain is unavailable or cannot serve the secret back.
-
-Writes the credential store atomically, so an interrupted write can no longer truncate the file and appear as a logout from every deployment.

--- a/changelog/150.fix.md
+++ b/changelog/150.fix.md
@@ -1,3 +1,3 @@
-Keeps access tokens, refresh tokens and identity assertions in the OS keychain when it can hold them, writing them to `credentials.json` only when the keychain is unavailable.
-Writes the credential store atomically, so an interrupted write can no longer appear as a logout from every deployment.
-Run `bookshelf auth logout` and log in again to clear any secrets already written to disk.
+Keeps access tokens, refresh tokens and identity assertions in the OS keychain when it can hold them,
+writing them to `credentials.json` only when the keychain is unavailable.
+Writes the credential store atomically.

--- a/changelog/150.fix.md
+++ b/changelog/150.fix.md
@@ -1,0 +1,3 @@
+Keeps access tokens, refresh tokens and identity assertions in the OS keychain when it can hold them, writing them to `credentials.json` only when the keychain is unavailable.
+Writes the credential store atomically, so an interrupted write can no longer appear as a logout from every deployment.
+Run `bookshelf auth logout` and log in again to clear any secrets already written to disk.

--- a/packages/bookshelf/src/bookshelf/_core/credentials.py
+++ b/packages/bookshelf/src/bookshelf/_core/credentials.py
@@ -9,14 +9,11 @@ Secrets have two possible homes:
 1. **OS keychain** (primary, hardened store) under service name ``"bookshelf"``
    with one username per record secret (``"<key>:access_token"`` and friends).
    On read the keychain value takes precedence over the file copy.
-2. **0600 JSON file** (secondary, compatibility store) at the ``platformdirs``
+2. **JSON file** (secondary, compatibility store) at the ``platformdirs``
    user-config path ``bookshelf/credentials.json``.
-   The file always holds the record index, because that is what names the keychain entries.
-   It holds a secret only when the keychain could not take it.
+   This file is only readable by the current user.
 
-When no keychain backend is available every keychain call degrades silently
-to the file-only path.
-Loading never refreshes, the credential providers own refresh.
+When no keychain backend is available every keychain call degrades silently to the file-only path.
 """
 
 import json
@@ -90,11 +87,7 @@ def _keychain_call(operation: str, *args: str) -> str | None:
 
 
 def _keychain_set(username: str, value: str) -> bool:
-    """Store one secret and confirm it can be read back.
-
-    The return value decides whether the file copy is needed,
-    so a backend that accepts a write it cannot serve must count as a failure.
-    """
+    """Store one secret and confirm it can be read back."""
     _keychain_call("set_password", username, value)
     return _keychain_get(username) == value
 
@@ -137,18 +130,11 @@ def _read_store() -> dict[str, Any]:
 
 
 def _write_store(store: dict[str, Any]) -> None:
-    """Replace the store file atomically, so a partial write cannot destroy it.
-
-    The temporary file is a sibling of the real one,
-    because ``os.replace`` is only atomic within a single filesystem.
-    """
     creds_path = credentials_path()
     creds_path.parent.mkdir(parents=True, exist_ok=True)
+    # Make a temp file and then os.remove to avoid corrupted writes
     temporary = creds_path.with_name(f"{creds_path.name}.{os.getpid()}.tmp")
     try:
-        # Created 0600 up front.
-        # A chmod after the write would leave a window
-        # where the secrets are world readable.
         fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)
         try:
             os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)

--- a/packages/bookshelf/src/bookshelf/_core/credentials.py
+++ b/packages/bookshelf/src/bookshelf/_core/credentials.py
@@ -129,20 +129,29 @@ def _read_store() -> dict[str, Any]:
 
 
 def _write_store(store: dict[str, Any]) -> None:
+    """Replace the store file atomically, so a partial write cannot destroy it.
+
+    The temporary file is a sibling of the real one,
+    because ``os.replace`` is only atomic within a single filesystem.
+    """
     creds_path = credentials_path()
     creds_path.parent.mkdir(parents=True, exist_ok=True)
-    # Created 0600 up front.
-    # A chmod after the write would leave a window
-    # where the secrets are world readable.
-    fd = os.open(creds_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)
+    temporary = creds_path.with_name(f"{creds_path.name}.{os.getpid()}.tmp")
     try:
-        os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
-    except OSError:
-        os.close(fd)
-        raise
-    with os.fdopen(fd, "w") as f:
-        json.dump(store, f, indent=2)
-    creds_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        # Created 0600 up front.
+        # A chmod after the write would leave a window
+        # where the secrets are world readable.
+        fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)
+        try:
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            os.close(fd)
+            raise
+        with os.fdopen(fd, "w") as f:
+            json.dump(store, f, indent=2)
+        os.replace(temporary, creds_path)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def _record_to_credentials(key: str, record: dict[str, Any]) -> StoredCredentials | None:

--- a/packages/bookshelf/src/bookshelf/_core/credentials.py
+++ b/packages/bookshelf/src/bookshelf/_core/credentials.py
@@ -4,13 +4,15 @@ The store holds several records at once, keyed by deployment plus identity kind
 (``user`` for a WorkOS login, ``agent`` for a Bookshelf agent identity).
 One record per deployment is active, and one deployment is the default.
 
-Secrets are dual-written:
+Secrets have two possible homes:
 
 1. **OS keychain** (primary, hardened store) under service name ``"bookshelf"``
    with one username per record secret (``"<key>:access_token"`` and friends).
    On read the keychain value takes precedence over the file copy.
 2. **0600 JSON file** (secondary, compatibility store) at the ``platformdirs``
    user-config path ``bookshelf/credentials.json``.
+   The file always holds the record index, because that is what names the keychain entries.
+   It holds a secret only when the keychain could not take it.
 
 When no keychain backend is available every keychain call degrades silently
 to the file-only path.
@@ -87,8 +89,14 @@ def _keychain_call(operation: str, *args: str) -> str | None:
         return None
 
 
-def _keychain_set(username: str, value: str) -> None:
+def _keychain_set(username: str, value: str) -> bool:
+    """Store one secret and confirm it can be read back.
+
+    The return value decides whether the file copy is needed,
+    so a backend that accepts a write it cannot serve must count as a failure.
+    """
     _keychain_call("set_password", username, value)
+    return _keychain_get(username) == value
 
 
 def _keychain_get(username: str) -> str | None:
@@ -253,25 +261,30 @@ def save_credentials(
     api_url = normalise_api_url(api_url)
     key = record_key(api_url, kind)
 
-    _keychain_set(f"{key}:access_token", access_token)
-    if refresh_token is not None:
-        _keychain_set(f"{key}:refresh_token", refresh_token)
-    else:
-        _keychain_delete(f"{key}:refresh_token")
-    if identity_assertion is not None:
-        _keychain_set(f"{key}:identity_assertion", identity_assertion)
-    else:
-        _keychain_delete(f"{key}:identity_assertion")
+    secrets: dict[str, str | None] = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "identity_assertion": identity_assertion,
+    }
+    # A secret reaches the file only when the keychain could not take it.
+    # The record itself always stays in the file,
+    # because it is the index that names the keychain entries.
+    for field in _SECRET_FIELDS:
+        value = secrets[field]
+        if value is None:
+            _keychain_delete(f"{key}:{field}")
+        elif _keychain_set(f"{key}:{field}", value):
+            secrets[field] = None
 
     store = _read_store()
     store["records"][key] = {
-        "access_token": access_token,
+        "access_token": secrets["access_token"],
         "token_type": token_type,
         "expires_at": expires_at.isoformat() if expires_at else None,
         "api_url": api_url,
-        "refresh_token": refresh_token,
+        "refresh_token": secrets["refresh_token"],
         "kind": kind,
-        "identity_assertion": identity_assertion,
+        "identity_assertion": secrets["identity_assertion"],
         "assertion_expires_at": assertion_expires_at.isoformat() if assertion_expires_at else None,
         "subject": subject,
         "organization_id": organization_id,

--- a/packages/bookshelf/tests/test_core_credentials.py
+++ b/packages/bookshelf/tests/test_core_credentials.py
@@ -45,6 +45,28 @@ def test_round_trip_with_file_permissions(isolated_store: Path) -> None:
     assert mode == 0o600
 
 
+def test_save_leaves_no_temporary_file_behind(isolated_store: Path) -> None:
+    credentials.save_credentials("tok", api_url="https://api.test")
+    assert isolated_store.exists()
+    assert stat.S_IMODE(isolated_store.stat().st_mode) == 0o600
+    leftovers = [
+        entry.name for entry in isolated_store.parent.iterdir() if entry.name.endswith(".tmp")
+    ]
+    assert leftovers == []
+
+
+def test_second_save_replaces_the_store_without_losing_records(isolated_store: Path) -> None:
+    credentials.save_credentials("a", api_url="https://api.test")
+    credentials.save_credentials("b", api_url="https://staging.test")
+
+    data = json.loads(isolated_store.read_text())
+    assert set(data["records"]) == {
+        credentials.record_key("https://api.test", "user"),
+        credentials.record_key("https://staging.test", "user"),
+    }
+    assert stat.S_IMODE(isolated_store.stat().st_mode) == 0o600
+
+
 def test_existing_store_permissions_are_tightened_before_write(
     isolated_store: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/bookshelf/tests/test_core_credentials.py
+++ b/packages/bookshelf/tests/test_core_credentials.py
@@ -21,7 +21,12 @@ def isolated_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(credentials, "credentials_path", lambda: path)
     # Tests must never touch the real OS keychain.
     store: dict[str, str] = {}
-    monkeypatch.setattr(credentials, "_keychain_set", store.__setitem__)
+
+    def fake_set(username: str, value: str) -> bool:
+        store[username] = value
+        return True
+
+    monkeypatch.setattr(credentials, "_keychain_set", fake_set)
     monkeypatch.setattr(credentials, "_keychain_get", store.get)
     monkeypatch.setattr(credentials, "_keychain_delete", lambda k: store.pop(k, None))
     return path
@@ -123,10 +128,15 @@ def test_missing_or_corrupt_file_returns_none(isolated_store: Path) -> None:
 
 
 def test_clear_removes_file_and_keychain(isolated_store: Path) -> None:
-    credentials.save_credentials("tok", api_url="https://api.test")
+    credentials.save_credentials(
+        "at", api_url="https://api.test", refresh_token="rt", identity_assertion="ia"
+    )
+    key = credentials.record_key("https://api.test", "user")
     credentials.clear_credentials()
     assert not isolated_store.exists()
     assert credentials.load_credentials() is None
+    for field in credentials._SECRET_FIELDS:
+        assert credentials._keychain_get(f"{key}:{field}") is None
 
 
 def test_expiry_derived_from_jwt_exp_when_absent(isolated_store: Path) -> None:
@@ -225,6 +235,91 @@ def test_clear_one_deployment_leaves_the_others(isolated_store: Path) -> None:
     assert remaining is not None
     # The default deployment moved off the cleared one.
     assert credentials.load_credentials() is not None
+
+
+def test_working_keychain_keeps_every_secret_out_of_the_file(isolated_store: Path) -> None:
+    credentials.save_credentials(
+        "at",
+        api_url="https://api.test",
+        refresh_token="rt",
+        identity_assertion="ia",
+    )
+
+    raw = isolated_store.read_text()
+    for secret in ("at", "rt", "ia"):
+        assert f'"{secret}"' not in raw
+
+    loaded = credentials.load_credentials()
+    assert loaded is not None
+    assert loaded.access_token == "at"
+    assert loaded.refresh_token == "rt"
+    assert loaded.identity_assertion == "ia"
+
+
+def test_absent_backend_falls_back_to_the_file_copy(
+    isolated_store: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no keychain to hold them the secrets must still be persisted."""
+
+    class BrokenKeyring:
+        def set_password(self, *args: object) -> None:
+            raise RuntimeError("no keychain backend")
+
+        def get_password(self, *args: object) -> str:
+            raise RuntimeError("no keychain backend")
+
+    import sys
+
+    monkeypatch.setattr(credentials, "_keychain_set", _REAL_KEYCHAIN_SET)
+    monkeypatch.setattr(credentials, "_keychain_get", _REAL_KEYCHAIN_GET)
+    monkeypatch.setitem(sys.modules, "keyring", BrokenKeyring())
+    credentials.save_credentials(
+        "at", api_url="https://api.test", refresh_token="rt", identity_assertion="ia"
+    )
+
+    key = credentials.record_key("https://api.test", "user")
+    record = json.loads(isolated_store.read_text())["records"][key]
+    assert record["access_token"] == "at"
+    assert record["refresh_token"] == "rt"
+    assert record["identity_assertion"] == "ia"
+
+    loaded = credentials.load_credentials()
+    assert loaded is not None
+    assert loaded.access_token == "at"
+    assert loaded.refresh_token == "rt"
+    assert loaded.identity_assertion == "ia"
+
+
+def test_backend_that_cannot_serve_a_write_falls_back_to_the_file_copy(
+    isolated_store: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A write the backend accepts but cannot read back must not lose the secret."""
+
+    class LyingKeyring:
+        def set_password(self, *args: object) -> None:
+            return None
+
+        def get_password(self, *args: object) -> str | None:
+            return None
+
+    import sys
+
+    monkeypatch.setattr(credentials, "_keychain_set", _REAL_KEYCHAIN_SET)
+    monkeypatch.setattr(credentials, "_keychain_get", _REAL_KEYCHAIN_GET)
+    monkeypatch.setitem(sys.modules, "keyring", LyingKeyring())
+    credentials.save_credentials(
+        "at", api_url="https://api.test", refresh_token="rt", identity_assertion="ia"
+    )
+
+    key = credentials.record_key("https://api.test", "user")
+    record = json.loads(isolated_store.read_text())["records"][key]
+    assert record["access_token"] == "at"
+    assert record["refresh_token"] == "rt"
+    assert record["identity_assertion"] == "ia"
+
+    loaded = credentials.load_credentials()
+    assert loaded is not None
+    assert loaded.access_token == "at"
 
 
 def test_keychain_failure_degrades_to_file(

--- a/packages/bookshelf/tests/test_core_credentials.py
+++ b/packages/bookshelf/tests/test_core_credentials.py
@@ -19,7 +19,8 @@ _REAL_KEYCHAIN_GET = credentials._keychain_get
 def isolated_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     path = tmp_path / "credentials.json"
     monkeypatch.setattr(credentials, "credentials_path", lambda: path)
-    # Tests must never touch the real OS keychain.
+
+    # Mock the OS keychain
     store: dict[str, str] = {}
 
     def fake_set(username: str, value: str) -> bool:


### PR DESCRIPTION
Hardens the credential store write path in two ways.

**The keychain becomes the primary store in practice.** The module docstring already described the OS keychain as the hardened store and the JSON file as a compatibility store, but `save_credentials` wrote every secret to the file unconditionally, so the keychain was never the sole holder. `_keychain_set` now confirms a write by reading it back, and a secret reaches the file only when the keychain could not take it. The record index always stays in the file, because it is what names the keychain entries.

The read back matters. A backend that accepts a write it cannot serve would otherwise cause silent credential loss, which is worse than the file copy it replaces.

**Store writes become atomic.** `_write_store` opened the real path with `O_TRUNC` and wrote in place, while `_read_store` silently returns an empty store on a decode error. So an interrupted write appeared as a logout from every deployment. It now writes a 0600 sibling temp file and `os.replace`s it into position.

`STORE_VERSION` is deliberately unchanged. Bumping it would make `_read_store` discard every existing record and log out every user on upgrade.

Behaviour change worth noting: a `credentials.json` copied to another machine no longer carries secrets, because they live in that machine's keychain. Existing installations keep whatever is already on disk until the next save, so running `bookshelf auth logout` and logging in again is the way to clear it.

Verified across all three paths: with a working keychain no secret appears in the file and loading still works, with no keyring backend the file fallback is intact, and with a backend that accepts a write it cannot serve the secret falls back to the file. `test_cli_auth_offline.py` passes unchanged.
