### PR TITLE
chore: keep the notebooks feedstock excluded from type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ follow_imports = "normal"
 exclude = [
     "build",
     "dist",
+    "notebooks",
     "scripts",
 ]
 


### PR DESCRIPTION
Restores `notebooks` to the root mypy `exclude` list.

PR #148 removed `notebooks`, `stubs` and `tests` from that list on the premise that all three directories were being deleted. Dropping `stubs` and `tests` was correct and they are gone. Dropping `notebooks` was not, because the directory is the dataset feedstock and stayed. The equivalent ruff exclusion was restored in #147, so this brings the mypy side back into line.

The practical impact today is small, because nothing runs mypy from the repository root any more. Both CI and `make checks` run `cd packages/bookshelf && mypy src`, which reads the package's own configuration. The value here is that the root configuration stops being quietly wrong, so the first person to run mypy from the root does not get a wall of errors from feedstock that targets the retired V1 API.

Verified on the merged integration branch: 441 tests pass, `make checks` exits 0, `make docs-strict` exits 0, and `ruff check` passes across the whole repository including `notebooks/`.
