### PR TITLE
fix: repair the licence check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,10 @@ changelog-draft:  ## compile a draft of the next changelog
 licence-check:  ## Check that licences of the dependencies are suitable
 	# Will likely fail on Windows, but Makefiles are in general not Windows
 	# compatible so we're not too worried
-	uv export --without=tests --without=docs --without=dev > $(TEMP_FILE)
+	uv export --no-group dev --no-emit-workspace > $(TEMP_FILE)
+	# liccheck needs pip and pkg_resources in its own environment, so the dev group
+	# carries both. setuptools is pinned below 81 because later versions dropped
+	# pkg_resources, which liccheck still imports.
 	uv run liccheck -r $(TEMP_FILE) -R licence-check.txt
 	rm -f $(TEMP_FILE)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dev = [
     "mkdocs-jupyter>=0.24.0",
     "mike>=2.1.3",
     "mkdocs-minify-plugin>=0.8.0",
+    "setuptools<81",
+    "pip>=26.1.2",
 ]
 
 [tool.uv.workspace]
@@ -134,6 +136,7 @@ authorized_licenses = [
     "bsd",
     "bsd license",
     "BSD 3-Clause",
+    "BSD-3-Clause",
     "CC0",
     "apache",
     "apache 2.0",
@@ -153,6 +156,7 @@ authorized_licenses = [
     "Mozilla Public License 2.0 (MPL 2.0)",
     "python software foundation",
     "python software foundation license",
+    "PSF-2.0",
     "zpl 2.1",
 ]
 # This starting list is relatively conservative. Depending on the project, it

--- a/uv.lock
+++ b/uv.lock
@@ -357,12 +357,14 @@ dev = [
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
     { name = "pandas-stubs" },
+    { name = "pip" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "setuptools" },
     { name = "towncrier" },
     { name = "types-pyyaml" },
 ]
@@ -385,12 +387,14 @@ dev = [
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.25.0" },
     { name = "mypy", specifier = ">=1.2.0" },
     { name = "pandas-stubs", specifier = ">=2.2.3.241009" },
+    { name = "pip", specifier = ">=26.1.2" },
     { name = "pre-commit", specifier = ">=3.3.1" },
     { name = "pytest", specifier = ">=7.3.1" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-mock", specifier = ">=3.11.1" },
     { name = "pytest-xdist", specifier = ">=3.3.1" },
     { name = "ruff", specifier = "==0.15.0" },
+    { name = "setuptools", specifier = "<81" },
     { name = "towncrier", specifier = ">=23.6.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20240917" },
 ]
@@ -2032,6 +2036,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pip"
+version = "26.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2742,6 +2755,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c", size = 52289, upload-time = "2022-05-26T13:35:23.454Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177", size = 15552, upload-time = "2022-05-26T13:35:21.206Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Repairs `make licence-check`, which has been failing before it checked anything.

The target had four stacked faults, and fixing any one of them only surfaces the next:

- `uv export --without=...` uses a flag current uv does not accept. The replacement is `--no-group`.
- Two of the three groups it named, `tests` and `docs`, do not exist. Only `dev` is defined, so the other two were leftovers from the retired two package layout.
- The export emitted the workspace member as an editable path (`-e ./packages/bookshelf`), which is not a specifier liccheck can resolve. `--no-emit-workspace` drops it.
- liccheck imports both `pip` and `pkg_resources` from its own environment, and a uv created virtual environment provides neither. An overlay via `uv run --with` does not help, because liccheck resolves them from the project environment. Both are now in the dev group.

`setuptools` is pinned below 81 because later versions removed `pkg_resources`, which liccheck still imports unconditionally. That pin is load bearing and the recipe carries a comment saying so.

Two SPDX spellings are added to `[tool.liccheck] authorized_licenses`: `BSD-3-Clause` and `PSF-2.0`. Both are licences the policy already accepted in prose form, listed as `BSD 3-Clause` with spaces and `python software foundation`. `unauthorized_licenses` is untouched, and no package was ever reported as unauthorized.

Verified on this branch: `make licence-check` exits 0 twice in a row and reports 29 packages, all authorised, with 0 unknown and 0 unauthorized. `make checks` exits 0 and the suite is unchanged at 441 passing. `licence-check.txt` is already gitignored, so no stray report is left behind.

Wiring this into CI is deliberately left for a follow up. The target has been broken long enough that nobody knows whether it stays green as dependencies move, so it is worth running by hand across a few dependency bumps before it blocks merges.
