### PR TITLE
fix: verify a downloaded resource off the event loop

### DIFF
--- a/changelog/155.fix.md
+++ b/changelog/155.fix.md
@@ -1,0 +1,2 @@
+Hashes a freshly downloaded resource off the event loop when fetching asynchronously.
+Verification previously ran inline, so a large download stalled every other task on the loop for the duration of the hash.

--- a/packages/bookshelf/src/bookshelf/_consume/resources.py
+++ b/packages/bookshelf/src/bookshelf/_consume/resources.py
@@ -586,7 +586,8 @@ class AsyncResource(_ResourceHandle):
         download = await self._client.get_resource_download_async(self.tracking_id)
         with self._cache.stage(content_hash) as temporary:
             await self._client.stream_url_to_path_async(download.presigned_url, temporary)
-            verify_path(temporary, content_hash)
+            # Verification hashes the whole downloaded file, so run it off the event loop too.
+            await asyncio.to_thread(verify_path, temporary, content_hash)
         return require_cached(self._cache, content_hash)
 
 

--- a/packages/bookshelf/tests/test_consume_async_hashing.py
+++ b/packages/bookshelf/tests/test_consume_async_hashing.py
@@ -1,0 +1,125 @@
+"""Async resource fetching must never hash a file on the event loop.
+
+Hashing a multi gigabyte climate dataset takes seconds,
+so doing it inline stalls every other task on the loop.
+The cache hit path was already careful about this and the download path was not,
+which is the drift these tests pin down.
+"""
+
+import asyncio
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bookshelf._consume import resources
+from bookshelf._consume.integrity import HashMismatchError
+from bookshelf._consume.resources import AsyncResource
+from bookshelf.cache import ContentCache
+
+CONTENT = b"year,value\n2020,1.0\n"
+TRACKING_ID = "11111111-2222-3333-4444-555555555555"
+
+
+def _content_hash(payload: bytes) -> str:
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+class _Metadata:
+    """The two attributes the fetch path reads off a resource record."""
+
+    def __init__(self, content_hash: str) -> None:
+        self.hash = content_hash
+        self.type = "timeseries"
+
+
+class _Download:
+    def __init__(self) -> None:
+        self.presigned_url = "https://storage.test/object"
+
+
+class _FakeClient:
+    """Serves one object, writing it straight to the destination path."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+        self.downloads = 0
+
+    async def get_resource_download_async(self, tracking_id: Any) -> _Download:
+        return _Download()
+
+    async def stream_url_to_path_async(self, url: str, destination: Path) -> None:
+        self.downloads += 1
+        destination.write_bytes(self._payload)
+
+
+@pytest.fixture
+def offloaded(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record every function handed to a worker thread, and still run it."""
+    names: list[str] = []
+    original = asyncio.to_thread
+
+    async def spy(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        names.append(getattr(func, "__name__", repr(func)))
+        return await original(func, *args, **kwargs)
+
+    monkeypatch.setattr(resources.asyncio, "to_thread", spy)
+    return names
+
+
+def _resource(tmp_path: Path, client: _FakeClient, content_hash: str) -> AsyncResource:
+    return AsyncResource(
+        client,  # type: ignore[arg-type]
+        ContentCache(base_dir=tmp_path),
+        TRACKING_ID,
+        metadata=_Metadata(content_hash),  # type: ignore[arg-type]
+    )
+
+
+async def test_a_downloaded_file_is_verified_off_the_event_loop(
+    tmp_path: Path, offloaded: list[str]
+) -> None:
+    client = _FakeClient(CONTENT)
+    resource = _resource(tmp_path, client, _content_hash(CONTENT))
+
+    path = await resource.as_path()
+
+    assert path.read_bytes() == CONTENT
+    assert client.downloads == 1
+    assert "verify_path" in offloaded, (
+        "the freshly downloaded file was hashed on the event loop, "
+        f"only these ran in a worker thread: {offloaded}"
+    )
+
+
+async def test_a_cache_hit_is_verified_off_the_event_loop(
+    tmp_path: Path, offloaded: list[str]
+) -> None:
+    content_hash = _content_hash(CONTENT)
+    cache = ContentCache(base_dir=tmp_path)
+    cache.put(content_hash, CONTENT)
+    client = _FakeClient(CONTENT)
+    resource = AsyncResource(
+        client,  # type: ignore[arg-type]
+        cache,
+        TRACKING_ID,
+        metadata=_Metadata(content_hash),  # type: ignore[arg-type]
+    )
+
+    path = await resource.as_path()
+
+    assert path.read_bytes() == CONTENT
+    assert client.downloads == 0
+    assert "cached_if_verified" in offloaded
+
+
+async def test_a_corrupt_download_still_raises_and_is_not_cached(tmp_path: Path) -> None:
+    declared = _content_hash(b"the resource the server promised")
+    client = _FakeClient(b"something else entirely")
+    resource = _resource(tmp_path, client, declared)
+
+    with pytest.raises(HashMismatchError):
+        await resource.as_path()
+
+    assert list(tmp_path.iterdir()) == [], "a file failing verification must not enter the cache"


### PR DESCRIPTION
Hashes a freshly downloaded resource off the event loop, which the async fetch path was already careful to do everywhere else.

`AsyncResource._ensure_cached` moves the cache hit verification into a worker thread and carries a comment saying why:

```python
# A cache hit hashes the whole file on disk, so run it off the event loop.
cached = await asyncio.to_thread(cached_if_verified, self._cache, content_hash)
```

Six lines later it then hashed the freshly downloaded file inline, on the loop. Verifying a multi gigabyte climate dataset takes seconds, so every other task on the loop stalled for the full SHA256. The sync twin is unaffected, because there is no loop to block.

This is the drift bug that motivated generating the client methods in a sibling change. The fix was applied to one twin of a hand duplicated pair and not the other, and nothing caught it. Note that the signature level parity test added alongside the client generation would **not** have caught this one either, because it is a body level difference rather than a signature level one.

Adds `tests/test_consume_async_hashing.py`, the first test to cover the consume layer at all. Three cases:

- A downloaded file is verified off the event loop. This is the regression test. It fails on the unfixed code with `AssertionError: the freshly downloaded file was hashed on the event loop, only these ran in a worker thread: ['cached_if_verified']`, which was confirmed by reverting the fix and re-running.
- A cache hit is verified off the event loop, pinning the behaviour that was already correct so it cannot regress the other way.
- A download whose content does not match its declared hash raises `HashMismatchError` and leaves nothing in the cache.

The tests assert on which functions reach a worker thread rather than on timing, so there is nothing flaky about them.

Verified: 444 passed, mypy clean over 52 files, ruff check and format clean.
