### PR TITLE
refactor: retire the seams that never had a second adapter

### DIFF
--- a/changelog/157.fix.md
+++ b/changelog/157.fix.md
@@ -1,0 +1,1 @@
+Raises a typed `DataFrameSupportError` with an install hint from `as_polars()` and `as_arrow()` when the `dataframes` extra is missing, instead of a bare `ImportError`.

--- a/changelog/157.fix.md
+++ b/changelog/157.fix.md
@@ -1,1 +1,2 @@
-Raises a typed `DataFrameSupportError` with an install hint from `as_polars()` and `as_arrow()` when the `dataframes` extra is missing, instead of a bare `ImportError`.
+Raises a typed `DataFrameSupportError` with an install hint from `as_polars()` and `as_arrow()`
+when the `dataframes` extra is missing, instead of a bare `ImportError`.

--- a/changelog/157.improvement.md
+++ b/changelog/157.improvement.md
@@ -1,0 +1,3 @@
+Retires the seams that only ever had one adapter, so the constructors no longer carry parameters for a variation that never arrived.
+`retry` and `cache` are gone from `Bookshelf`, `AsyncBookshelf` and `BookshelfClient`, and `rand` is gone from `RetryPolicy.delay`.
+`transport` and `async_transport` stay, because they are the seam the tests reach through.

--- a/changelog/157.improvement.md
+++ b/changelog/157.improvement.md
@@ -1,3 +1,5 @@
-Retires the seams that only ever had one adapter, so the constructors no longer carry parameters for a variation that never arrived.
-`retry` and `cache` are gone from `Bookshelf`, `AsyncBookshelf` and `BookshelfClient`, and `rand` is gone from `RetryPolicy.delay`.
+Retires the seams that only ever had one adapter,
+so the constructors no longer carry parameters for a variation that never arrived.
+`retry` and `cache` are gone from `Bookshelf`, `AsyncBookshelf` and `BookshelfClient`,
+and `rand` is gone from `RetryPolicy.delay`.
 `transport` and `async_transport` stay, because they are the seam the tests reach through.

--- a/packages/bookshelf/src/bookshelf/_cli/auth.py
+++ b/packages/bookshelf/src/bookshelf/_cli/auth.py
@@ -35,23 +35,7 @@ CLAIM_GRANT = "urn:workos:agent-auth:grant-type:claim"
 
 _AGENT_PLATFORM = "bookshelf-cli"
 
-# Test seams:
-# polling waits,
-# the poll clock,
-# and the moment the ceremony instructions are out.
-_sleep = time.sleep
-_monotonic = time.monotonic
-
-
-def _claim_started(registration: models.ServiceAuthRegistrationResponse) -> None:
-    """Hook invoked once the ceremony instructions have been emitted."""
-
-
 auth_app = typer.Typer(help="Manage authentication for the Bookshelf API.", no_args_is_help=True)
-
-
-def _base_url(api_url: str | None) -> str:
-    return resolve_base_url(api_url)
 
 
 def _now() -> datetime:
@@ -97,7 +81,7 @@ def auth_login(
     json_output: bool = typer.Option(False, "--json", help="Emit the credential summary as JSON."),
 ) -> None:
     """Log in: through WorkOS as a human, or as an agent with --agent."""
-    base = _base_url(api_url)
+    base = resolve_base_url(api_url)
     with command_errors():
         if not agent:
             if claim or email is not None:
@@ -243,7 +227,6 @@ def _login_agent_claim(base: str, *, email: str, json_output: bool) -> None:
         note(f"  Enter code  {ceremony.user_code}")
         note("")
         note(f"Waiting for approval (expires in {max(ceremony.expires_in // 60, 1)} minutes)...")
-        _claim_started(registration)
         grant = _poll_claim(
             client,
             claim_token=registration.claim_token,
@@ -288,7 +271,7 @@ def _login_agent_claim(base: str, *, email: str, json_output: bool) -> None:
 def _poll_claim(
     client: BookshelfClient, *, claim_token: str, interval: int, expires_in: int
 ) -> models.TokenResponse:
-    deadline = _monotonic() + expires_in
+    deadline = time.monotonic() + expires_in
     wait = max(interval, 1)
     while True:
         try:
@@ -306,13 +289,13 @@ def _poll_claim(
                     "Run 'bookshelf auth login --agent --claim --email you@org.com' to retry.",
                     exit_code=EXIT_AUTH_REQUIRED,
                 ) from exc
-        if _monotonic() >= deadline:
+        if time.monotonic() >= deadline:
             raise CliError(
                 "claim ceremony expired before approval. "
                 "Run 'bookshelf auth login --agent --claim --email you@org.com' to retry.",
                 exit_code=EXIT_AUTH_REQUIRED,
             )
-        _sleep(wait)
+        time.sleep(wait)
 
 
 def _identity_for_token(base: str, access_token: str) -> models.UserResponse:
@@ -327,7 +310,7 @@ def auth_token(
     ),
 ) -> None:
     """Print the current access token to stdout and nothing else."""
-    base = _base_url(api_url)
+    base = resolve_base_url(api_url)
     with command_errors():
         source, stored = config.resolve_ambient_credential(base)
         if source is CredentialSource.ENV_TOKEN:
@@ -441,7 +424,7 @@ def auth_whoami(
     json_output: bool = typer.Option(False, "--json", help="Emit the report as JSON."),
 ) -> None:
     """Report the identity in play and which resolution step supplied it."""
-    base = _base_url(api_url)
+    base = resolve_base_url(api_url)
     with command_errors():
         source, stored = config.resolve_ambient_credential(base)
         if source in (CredentialSource.ENV_TOKEN, CredentialSource.CLIENT_CREDENTIALS):
@@ -585,7 +568,7 @@ def auth_logout(
     with command_errors():
         records = credentials.list_credentials()
         if not all_deployments:
-            base = _base_url(api_url)
+            base = resolve_base_url(api_url)
             records = [record for record in records if record.api_url == base]
             if not records:
                 note(f"Not logged in to {base}.")
@@ -669,7 +652,7 @@ def auth_switch(
             record for record in credentials.list_credentials() if record.subject == identity
         ]
         if api_url is not None:
-            base = _base_url(api_url)
+            base = resolve_base_url(api_url)
             records = [record for record in records if record.api_url == base]
         if not records:
             raise CliError(

--- a/packages/bookshelf/src/bookshelf/_cli/discovery.py
+++ b/packages/bookshelf/src/bookshelf/_cli/discovery.py
@@ -24,10 +24,6 @@ _LEADING_DIGITS = re.compile(r"^([0-9]+)(.*)$")
 _ASCII_DIGITS = re.compile(r"^[0-9]+$")
 
 
-def _client(api_url: str | None) -> BookshelfClient:
-    return BookshelfClient(resolve_base_url(api_url))
-
-
 def search(
     query: str | None = typer.Argument(
         None, help="Free text over name, title and summary. Optional."
@@ -56,7 +52,7 @@ def search(
 ) -> None:
     """Search volumes with free text and filters, which combine with AND."""
     with command_errors():
-        with _client(api_url) as client:
+        with BookshelfClient(resolve_base_url(api_url)) as client:
             if facets:
                 _emit_facets(client.get_catalogue_facets(), json_output)
                 return
@@ -140,7 +136,7 @@ def show(
     """Resolve one address and describe what is there, at whatever depth it is given."""
     with command_errors():
         parsed = parse_address(address)
-        with _client(api_url) as client:
+        with BookshelfClient(resolve_base_url(api_url)) as client:
             if parsed.version is None and parsed.entry is None:
                 _show_volume(client, parsed, json_output)
             else:

--- a/packages/bookshelf/src/bookshelf/_consume/frames.py
+++ b/packages/bookshelf/src/bookshelf/_consume/frames.py
@@ -55,13 +55,13 @@ def timeseries_frame(response: models.TimeseriesResponse) -> pd.DataFrame:
     return pd.DataFrame(response.data, index=index, columns=response.years)
 
 
-def _require(module: str, method: str) -> Any:
+def _require(module: str, caller: str) -> Any:
     """Import an optional dependency, reporting a missing extra as a typed error."""
     try:
         return importlib.import_module(module)
     except ImportError as exc:
         raise DataFrameSupportError(
-            f"{method} requires the 'dataframes' extra: pip install 'bookshelf[dataframes]'"
+            f"{caller} requires the 'dataframes' extra: pip install 'bookshelf[dataframes]'"
         ) from exc
 
 

--- a/packages/bookshelf/src/bookshelf/_consume/frames.py
+++ b/packages/bookshelf/src/bookshelf/_consume/frames.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import importlib
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bookshelf._core.frames import DataFrameSupportError
 from bookshelf._generated import models
@@ -54,21 +55,26 @@ def timeseries_frame(response: models.TimeseriesResponse) -> pd.DataFrame:
     return pd.DataFrame(response.data, index=index, columns=response.years)
 
 
+def _require(module: str, method: str) -> Any:
+    """Import an optional dependency, reporting a missing extra as a typed error."""
+    try:
+        return importlib.import_module(module)
+    except ImportError as exc:
+        raise DataFrameSupportError(
+            f"{method} requires the 'dataframes' extra: pip install 'bookshelf[dataframes]'"
+        ) from exc
+
+
 def polars_converter() -> Callable[[pd.DataFrame], pl.DataFrame]:
     """Import Polars and return a converter that keeps the index columns.
 
     Callers resolve the converter before fetching any data,
     so an install without the optional extra fails without making a request.
     """
-    try:
-        import polars as pl
-    except ImportError as exc:
-        raise DataFrameSupportError(
-            "as_polars() requires the 'dataframes' extra: pip install 'bookshelf[dataframes]'"
-        ) from exc
+    polars = _require("polars", "as_polars()")
 
     def convert(frame: pd.DataFrame) -> pl.DataFrame:
-        return pl.from_pandas(frame, include_index=True)
+        return polars.from_pandas(frame, include_index=True)  # type: ignore[no-any-return]
 
     return convert
 
@@ -79,15 +85,10 @@ def arrow_converter() -> Callable[[pd.DataFrame], pa.Table]:
     Callers resolve the converter before fetching any data,
     so an install without the optional extra fails without making a request.
     """
-    try:
-        import pyarrow as pa
-    except ImportError as exc:
-        raise DataFrameSupportError(
-            "as_arrow() requires the 'dataframes' extra: pip install 'bookshelf[dataframes]'"
-        ) from exc
+    pyarrow = _require("pyarrow", "as_arrow()")
 
     def convert(frame: pd.DataFrame) -> pa.Table:
-        return pa.Table.from_pandas(frame, preserve_index=True)
+        return pyarrow.Table.from_pandas(frame, preserve_index=True)
 
     return convert
 

--- a/packages/bookshelf/src/bookshelf/_consume/frames.py
+++ b/packages/bookshelf/src/bookshelf/_consume/frames.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import importlib
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from bookshelf._core.frames import DataFrameSupportError
+from bookshelf._core.frames import require_extra
 from bookshelf._generated import models
 
 if TYPE_CHECKING:
@@ -55,23 +54,13 @@ def timeseries_frame(response: models.TimeseriesResponse) -> pd.DataFrame:
     return pd.DataFrame(response.data, index=index, columns=response.years)
 
 
-def _require(module: str, caller: str) -> Any:
-    """Import an optional dependency, reporting a missing extra as a typed error."""
-    try:
-        return importlib.import_module(module)
-    except ImportError as exc:
-        raise DataFrameSupportError(
-            f"{caller} requires the 'dataframes' extra: pip install 'bookshelf[dataframes]'"
-        ) from exc
-
-
 def polars_converter() -> Callable[[pd.DataFrame], pl.DataFrame]:
     """Import Polars and return a converter that keeps the index columns.
 
     Callers resolve the converter before fetching any data,
     so an install without the optional extra fails without making a request.
     """
-    polars = _require("polars", "as_polars()")
+    polars = require_extra("polars", "as_polars()")
 
     def convert(frame: pd.DataFrame) -> pl.DataFrame:
         return polars.from_pandas(frame, include_index=True)  # type: ignore[no-any-return]
@@ -85,7 +74,7 @@ def arrow_converter() -> Callable[[pd.DataFrame], pa.Table]:
     Callers resolve the converter before fetching any data,
     so an install without the optional extra fails without making a request.
     """
-    pyarrow = _require("pyarrow", "as_arrow()")
+    pyarrow = require_extra("pyarrow", "as_arrow()")
 
     def convert(frame: pd.DataFrame) -> pa.Table:
         return pyarrow.Table.from_pandas(frame, preserve_index=True)

--- a/packages/bookshelf/src/bookshelf/_consume/frames.py
+++ b/packages/bookshelf/src/bookshelf/_consume/frames.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from bookshelf._core.frames import DataFrameSupportError
 from bookshelf._generated import models
 
 if TYPE_CHECKING:
@@ -59,7 +60,12 @@ def polars_converter() -> Callable[[pd.DataFrame], pl.DataFrame]:
     Callers resolve the converter before fetching any data,
     so an install without the optional extra fails without making a request.
     """
-    import polars as pl
+    try:
+        import polars as pl
+    except ImportError as exc:
+        raise DataFrameSupportError(
+            "as_polars() requires the 'dataframes' extra: pip install 'bookshelf[dataframes]'"
+        ) from exc
 
     def convert(frame: pd.DataFrame) -> pl.DataFrame:
         return pl.from_pandas(frame, include_index=True)
@@ -73,7 +79,12 @@ def arrow_converter() -> Callable[[pd.DataFrame], pa.Table]:
     Callers resolve the converter before fetching any data,
     so an install without the optional extra fails without making a request.
     """
-    import pyarrow as pa
+    try:
+        import pyarrow as pa
+    except ImportError as exc:
+        raise DataFrameSupportError(
+            "as_arrow() requires the 'dataframes' extra: pip install 'bookshelf[dataframes]'"
+        ) from exc
 
     def convert(frame: pd.DataFrame) -> pa.Table:
         return pa.Table.from_pandas(frame, preserve_index=True)

--- a/packages/bookshelf/src/bookshelf/_core/client.py
+++ b/packages/bookshelf/src/bookshelf/_core/client.py
@@ -53,14 +53,14 @@ class BookshelfClient:
         *,
         auth: AuthInput = UNSET,
         timeout: float = 30.0,
-        retry: RetryPolicy | None = None,
+        # The transports are the test seam: production always leaves them None.
         transport: httpx.BaseTransport | None = None,
         async_transport: httpx.AsyncBaseTransport | None = None,
     ) -> None:
         self._base_url = resolve_base_url(base_url).rstrip("/")
         self._auth = resolve_auth(auth, base_url=self._base_url)
         self._timeout = timeout
-        self._retry = retry if retry is not None else RetryPolicy()
+        self._retry = RetryPolicy()
         self._transport = transport
         self._async_transport = async_transport
         self._sync: httpx.Client | None = None

--- a/packages/bookshelf/src/bookshelf/_core/config.py
+++ b/packages/bookshelf/src/bookshelf/_core/config.py
@@ -19,6 +19,7 @@ import enum
 import os
 from collections.abc import Callable
 from datetime import UTC, datetime
+from typing import Any
 
 import httpx
 
@@ -160,7 +161,7 @@ def auth_from_stored(stored: credentials.StoredCredentials) -> httpx.Auth:
         token_url=f"{workos_base}/user_management/authenticate",
         client_id=workos_client_id,
         expires_at=stored.expires_at.timestamp() if stored.expires_at is not None else None,
-        on_rotate=_rotation_sink(stored),
+        on_rotate=_rotation_sink(stored, kind="user"),
     )
 
 
@@ -171,35 +172,42 @@ def _agent_auth_from_stored(stored: credentials.StoredCredentials) -> BsatAssert
         base_url=stored.api_url,
         access_token=stored.access_token,
         expires_at=stored.expires_at.timestamp() if stored.expires_at is not None else None,
-        on_rotate=_rotation_sink(stored),
+        on_rotate=_rotation_sink(stored, kind="agent"),
     )
 
 
 def _rotation_sink(
-    stored: credentials.StoredCredentials,
+    stored: credentials.StoredCredentials, *, kind: str
 ) -> Callable[[str, str | None, float | None], None]:
     """Build the callback that writes a rotated credential back over the record it came from.
 
     Both providers rotate one secret alongside the access token,
     a refresh token for a user and a reissued identity assertion for an agent,
     so they hand it over in the same position.
+    ``kind`` names the provider that was built, which is not always the record's own kind:
+    an agent record with no assertion is served by the refresh-token provider.
     """
-    rotates_assertion = stored.kind == "agent"
 
     def persist(access_token: str, secret: str | None, expires_at: float | None) -> None:
+        rotated: dict[str, Any] = (
+            {
+                "identity_assertion": secret,
+                "assertion_expires_at": stored.assertion_expires_at,
+                "claimed": stored.claimed,
+            }
+            if kind == "agent"
+            else {"refresh_token": secret}
+        )
         credentials.save_credentials(
             access_token,
             api_url=stored.api_url,
-            kind=stored.kind,
+            kind=kind,
             expires_at=(
                 datetime.fromtimestamp(expires_at, tz=UTC) if expires_at is not None else None
             ),
-            refresh_token=None if rotates_assertion else secret,
-            identity_assertion=secret if rotates_assertion else None,
-            assertion_expires_at=stored.assertion_expires_at if rotates_assertion else None,
             subject=stored.subject,
             organization_id=stored.organization_id,
-            claimed=stored.claimed if rotates_assertion else None,
+            **rotated,
         )
 
     return persist

--- a/packages/bookshelf/src/bookshelf/_core/config.py
+++ b/packages/bookshelf/src/bookshelf/_core/config.py
@@ -17,6 +17,7 @@ and an explicit ``auth=None`` stays unauthenticated.
 
 import enum
 import os
+from collections.abc import Callable
 from datetime import UTC, datetime
 
 import httpx
@@ -152,20 +153,6 @@ def auth_from_stored(stored: credentials.StoredCredentials) -> httpx.Auth:
         )
 
     workos_base = os.environ.get("BOOKSHELF_WORKOS_BASE_URL", _DEFAULT_WORKOS_BASE_URL)
-    api_url = stored.api_url
-
-    def persist(access_token: str, refresh_token: str | None, expires_at: float | None) -> None:
-        credentials.save_credentials(
-            access_token,
-            refresh_token=refresh_token,
-            expires_at=(
-                datetime.fromtimestamp(expires_at, tz=UTC) if expires_at is not None else None
-            ),
-            api_url=api_url,
-            kind="user",
-            subject=stored.subject,
-            organization_id=stored.organization_id,
-        )
 
     return RefreshTokenExchange(
         stored.access_token,
@@ -173,36 +160,49 @@ def auth_from_stored(stored: credentials.StoredCredentials) -> httpx.Auth:
         token_url=f"{workos_base}/user_management/authenticate",
         client_id=workos_client_id,
         expires_at=stored.expires_at.timestamp() if stored.expires_at is not None else None,
-        on_rotate=persist,
+        on_rotate=_rotation_sink(stored),
     )
 
 
 def _agent_auth_from_stored(stored: credentials.StoredCredentials) -> BsatAssertion:
-    api_url = stored.api_url
     assert stored.identity_assertion is not None
+    return BsatAssertion(
+        stored.identity_assertion,
+        base_url=stored.api_url,
+        access_token=stored.access_token,
+        expires_at=stored.expires_at.timestamp() if stored.expires_at is not None else None,
+        on_rotate=_rotation_sink(stored),
+    )
 
-    def persist(access_token: str, assertion: str, expires_at: float | None) -> None:
+
+def _rotation_sink(
+    stored: credentials.StoredCredentials,
+) -> Callable[[str, str | None, float | None], None]:
+    """Build the callback that writes a rotated credential back over the record it came from.
+
+    Both providers rotate one secret alongside the access token,
+    a refresh token for a user and a reissued identity assertion for an agent,
+    so they hand it over in the same position.
+    """
+    rotates_assertion = stored.kind == "agent"
+
+    def persist(access_token: str, secret: str | None, expires_at: float | None) -> None:
         credentials.save_credentials(
             access_token,
-            api_url=api_url,
-            kind="agent",
+            api_url=stored.api_url,
+            kind=stored.kind,
             expires_at=(
                 datetime.fromtimestamp(expires_at, tz=UTC) if expires_at is not None else None
             ),
-            identity_assertion=assertion,
-            assertion_expires_at=stored.assertion_expires_at,
+            refresh_token=None if rotates_assertion else secret,
+            identity_assertion=secret if rotates_assertion else None,
+            assertion_expires_at=stored.assertion_expires_at if rotates_assertion else None,
             subject=stored.subject,
             organization_id=stored.organization_id,
-            claimed=stored.claimed,
+            claimed=stored.claimed if rotates_assertion else None,
         )
 
-    return BsatAssertion(
-        stored.identity_assertion,
-        base_url=api_url,
-        access_token=stored.access_token,
-        expires_at=stored.expires_at.timestamp() if stored.expires_at is not None else None,
-        on_rotate=persist,
-    )
+    return persist
 
 
 def _workos_client_id(api_url: str) -> str | None:

--- a/packages/bookshelf/src/bookshelf/_core/frames.py
+++ b/packages/bookshelf/src/bookshelf/_core/frames.py
@@ -4,6 +4,7 @@ Lives in the parse layer because generators cannot reach binary content negotiat
 pandas and pyarrow are optional (``bookshelf[dataframes]``), so imports are deferred.
 """
 
+import importlib
 import io
 import json
 from typing import TYPE_CHECKING, Any
@@ -19,15 +20,18 @@ class DataFrameSupportError(BookshelfError):
     """Raised when frame conversion is requested without the ``dataframes`` extra installed."""
 
 
-def _pandas() -> Any:
+def require_extra(module: str, caller: str) -> Any:
+    """Import a module from the ``dataframes`` extra, reporting a missing one as a typed error.
+
+    ``caller`` names what the user was trying to do, so the message points at their call
+    rather than at the import.
+    """
     try:
-        import pandas
-    except ImportError as exc:  # pragma: no cover
+        return importlib.import_module(module)
+    except ImportError as exc:
         raise DataFrameSupportError(
-            "DataFrame conversion requires the 'dataframes' extra: "
-            "pip install 'bookshelf[dataframes]'"
+            f"{caller} requires the 'dataframes' extra: pip install 'bookshelf[dataframes]'"
         ) from exc
-    return pandas
 
 
 def require_payload(result: DataPayload | NotModified) -> DataPayload:
@@ -39,7 +43,7 @@ def require_payload(result: DataPayload | NotModified) -> DataPayload:
 
 def to_pandas(payload: DataPayload) -> "pd.DataFrame":
     """Convert a ``/data`` payload to a pandas DataFrame, dispatching on the negotiated format."""
-    pandas = _pandas()
+    pandas = require_extra("pandas", "DataFrame conversion")
     if payload.format == "json":
         rows = json.loads(payload.content)
         frame: pd.DataFrame = pandas.DataFrame(rows)

--- a/packages/bookshelf/src/bookshelf/_core/retry.py
+++ b/packages/bookshelf/src/bookshelf/_core/retry.py
@@ -19,8 +19,7 @@ class RetryPolicy:
     def should_retry_status(self, status_code: int) -> bool:
         return status_code >= 500
 
-    def delay(self, attempt: int, *, rand: random.Random | None = None) -> float:
+    def delay(self, attempt: int) -> float:
         """Sleep seconds before retry ``attempt`` (1-based: the first retry is attempt 1)."""
         ceiling = min(self.backoff_cap, self.backoff_base * (2 ** (attempt - 1)))
-        uniform = rand.uniform if rand is not None else random.uniform
-        return uniform(0.0, ceiling)
+        return random.uniform(0.0, ceiling)

--- a/packages/bookshelf/src/bookshelf/facade.py
+++ b/packages/bookshelf/src/bookshelf/facade.py
@@ -20,7 +20,6 @@ from bookshelf._consume.resources import (
 from bookshelf._core.client import BookshelfClient
 from bookshelf._core.config import UNSET, AuthInput
 from bookshelf._core.errors import BookshelfError, NotFoundError
-from bookshelf._core.retry import RetryPolicy
 from bookshelf._generated import models
 from bookshelf._produce import (
     Activity,
@@ -139,18 +138,16 @@ class Bookshelf(ProduceFacade):
         *,
         auth: AuthInput = UNSET,
         timeout: float = 30.0,
-        retry: RetryPolicy | None = None,
+        # The transport is the test seam: production always leaves it None.
         transport: httpx.BaseTransport | None = None,
-        cache: ContentCache | None = None,
     ) -> None:
         self._client = BookshelfClient(
             base_url,
             auth=auth,
             timeout=timeout,
-            retry=retry,
             transport=transport,
         )
-        self._cache = cache if cache is not None else ContentCache()
+        self._cache = ContentCache()
         self._produce_sink = LiveSink(self._client, self._cache)
 
     def __enter__(self) -> Self:
@@ -317,18 +314,16 @@ class AsyncBookshelf(AsyncProduceFacade):
         *,
         auth: AuthInput = UNSET,
         timeout: float = 30.0,
-        retry: RetryPolicy | None = None,
+        # The transport is the test seam: production always leaves it None.
         async_transport: httpx.AsyncBaseTransport | None = None,
-        cache: ContentCache | None = None,
     ) -> None:
         self._client = BookshelfClient(
             base_url,
             auth=auth,
             timeout=timeout,
-            retry=retry,
             async_transport=async_transport,
         )
-        self._cache = cache if cache is not None else ContentCache()
+        self._cache = ContentCache()
         self._produce_sink = AsyncLiveSink(self._client, self._cache)
 
     async def __aenter__(self) -> Self:

--- a/packages/bookshelf/tests/test_cli_claim_polling.py
+++ b/packages/bookshelf/tests/test_cli_claim_polling.py
@@ -1,0 +1,103 @@
+"""Tests for the claim-ceremony polling loop (``bookshelf._cli.auth._poll_claim``)."""
+
+from typing import Any
+
+import pytest
+
+from bookshelf._cli import auth
+from bookshelf._cli._runtime import EXIT_AUTH_REQUIRED, CliError
+from bookshelf._core.errors import OAuthProtocolError
+from bookshelf._generated import models
+
+GRANT = models.TokenResponse(
+    access_token="bsat_claimed",
+    token_type="Bearer",
+    expires_in=3600,
+    scope="read write",
+)
+
+
+class _StubClient:
+    """Answer each exchange with the next queued outcome, an exception or a grant."""
+
+    def __init__(self, outcomes: list[Any]) -> None:
+        self._outcomes = list(outcomes)
+        self.calls = 0
+
+    def agent_token_exchange(self, body: models.BodyAgentTokenExchange) -> models.TokenResponse:
+        assert body.grant_type == auth.CLAIM_GRANT
+        assert body.claim_token == "claim-1"
+        self.calls += 1
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome  # type: ignore[no-any-return]
+
+
+def _protocol_error(error: str) -> OAuthProtocolError:
+    return OAuthProtocolError("not yet.", error=error, status_code=400)
+
+
+@pytest.fixture
+def waits(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Capture the polling waits instead of actually sleeping."""
+    recorded: list[float] = []
+    monkeypatch.setattr(auth.time, "sleep", recorded.append)
+    return recorded
+
+
+def _poll(client: Any, *, interval: int = 1, expires_in: int = 300) -> models.TokenResponse:
+    return auth._poll_claim(
+        client,
+        claim_token="claim-1",
+        interval=interval,
+        expires_in=expires_in,
+    )
+
+
+def test_pending_polls_again_until_the_grant_arrives(waits: list[float]) -> None:
+    client = _StubClient([_protocol_error("authorization_pending"), GRANT])
+
+    assert _poll(client, interval=2) is GRANT
+    assert client.calls == 2
+    assert waits == [2]
+
+
+def test_slow_down_adds_five_seconds_to_the_wait(waits: list[float]) -> None:
+    client = _StubClient(
+        [_protocol_error("slow_down"), _protocol_error("slow_down"), GRANT],
+    )
+
+    assert _poll(client, interval=2) is GRANT
+    assert waits == [7, 12]
+
+
+def test_a_zero_interval_still_waits_a_second(waits: list[float]) -> None:
+    client = _StubClient([_protocol_error("authorization_pending"), GRANT])
+
+    _poll(client, interval=0)
+
+    assert waits == [1]
+
+
+def test_any_other_oauth_error_names_the_retry_command(waits: list[float]) -> None:
+    client = _StubClient([_protocol_error("access_denied")])
+
+    with pytest.raises(CliError) as raised:
+        _poll(client)
+
+    assert raised.value.exit_code == EXIT_AUTH_REQUIRED
+    assert "claim was not completed" in str(raised.value)
+    assert "bookshelf auth login --agent --claim" in str(raised.value)
+    assert waits == []
+
+
+def test_an_expired_ceremony_stops_polling(waits: list[float]) -> None:
+    client = _StubClient([_protocol_error("authorization_pending")])
+
+    with pytest.raises(CliError) as raised:
+        _poll(client, expires_in=0)
+
+    assert raised.value.exit_code == EXIT_AUTH_REQUIRED
+    assert "expired before approval" in str(raised.value)
+    assert waits == []

--- a/packages/bookshelf/tests/test_consume_frames.py
+++ b/packages/bookshelf/tests/test_consume_frames.py
@@ -1,8 +1,19 @@
 """Tests for the consumed-resource frame conversions (``bookshelf._consume.frames``)."""
 
-import pandas as pd
+import sys
 
-from bookshelf._consume.frames import long_timeseries, timeseries_frame, wide_timeseries
+import pandas as pd
+import pytest
+
+from bookshelf._consume.frames import (
+    arrow_converter,
+    long_timeseries,
+    polars_converter,
+    timeseries_frame,
+    wide_timeseries,
+)
+from bookshelf._core.errors import BookshelfError
+from bookshelf._core.frames import DataFrameSupportError
 from bookshelf._generated import models
 
 
@@ -38,3 +49,27 @@ def test_long_timeseries_handles_a_response_without_an_index() -> None:
 def test_wide_timeseries_leaves_a_year_only_frame_alone() -> None:
     wide = pd.DataFrame({"2000": [1.5]})
     assert list(wide_timeseries(wide).columns) == ["2000"]
+
+
+@pytest.mark.parametrize(
+    ("module", "converter", "method"),
+    [
+        ("polars", polars_converter, "as_polars()"),
+        ("pyarrow", arrow_converter, "as_arrow()"),
+    ],
+)
+def test_a_missing_extra_is_reported_as_a_bookshelf_error(
+    monkeypatch: pytest.MonkeyPatch,
+    module: str,
+    converter: object,
+    method: str,
+) -> None:
+    """A caller catching BookshelfError should not have to catch ImportError as well."""
+    monkeypatch.setitem(sys.modules, module, None)
+
+    with pytest.raises(DataFrameSupportError) as raised:
+        converter()  # type: ignore[operator]
+
+    assert isinstance(raised.value, BookshelfError)
+    assert method in str(raised.value)
+    assert "pip install 'bookshelf[dataframes]'" in str(raised.value)

--- a/packages/bookshelf/tests/test_core_client.py
+++ b/packages/bookshelf/tests/test_core_client.py
@@ -13,14 +13,12 @@ from bookshelf._generated import models
 from tests import _core_payloads as payloads
 
 BASE_URL = "https://bookshelf.test"
-NO_RETRY = RetryPolicy(max_attempts=1)
-FAST_RETRY = RetryPolicy(max_attempts=3, backoff_base=0.0, backoff_cap=0.0)
+ATTEMPTS = RetryPolicy().max_attempts
 
 
-def make_client(handler: Any, *, retry: RetryPolicy = NO_RETRY, **kwargs: Any) -> BookshelfClient:
+def make_client(handler: Any, **kwargs: Any) -> BookshelfClient:
     return BookshelfClient(
         BASE_URL,
-        retry=retry,
         transport=httpx.MockTransport(handler),
         async_transport=httpx.MockTransport(handler),
         **kwargs,
@@ -163,13 +161,13 @@ def test_transient_5xx_is_retried_then_succeeds() -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         calls["count"] += 1
-        if calls["count"] < 3:
+        if calls["count"] < ATTEMPTS:
             return httpx.Response(503, text="unavailable")
         return httpx.Response(200, json=payloads.BOOK_LIST)
 
-    with make_client(handler, retry=FAST_RETRY) as client:
+    with make_client(handler) as client:
         response = client.list_books()
-    assert calls["count"] == 3
+    assert calls["count"] == ATTEMPTS
     assert response.total == 0
 
 
@@ -180,9 +178,9 @@ def test_5xx_after_exhausted_retries_raises_server_error() -> None:
         calls["count"] += 1
         return httpx.Response(500, text="boom")
 
-    with make_client(handler, retry=FAST_RETRY) as client, pytest.raises(ServerError):
+    with make_client(handler) as client, pytest.raises(ServerError):
         client.list_books()
-    assert calls["count"] == 3
+    assert calls["count"] == ATTEMPTS
 
 
 async def test_network_failure_retries_then_raises_transport_error() -> None:
@@ -192,10 +190,10 @@ async def test_network_failure_retries_then_raises_transport_error() -> None:
         calls["count"] += 1
         raise httpx.ConnectError("connection refused")
 
-    async with make_client(handler, retry=FAST_RETRY) as client:
+    async with make_client(handler) as client:
         with pytest.raises(TransportError):
             await client.list_books_async()
-    assert calls["count"] == 3
+    assert calls["count"] == ATTEMPTS
 
 
 def test_4xx_is_never_retried() -> None:
@@ -210,7 +208,7 @@ def test_4xx_is_never_retried() -> None:
         )
 
     with (
-        make_client(handler, retry=FAST_RETRY) as client,
+        make_client(handler) as client,
         pytest.raises(NotFoundError, match="gone"),
     ):
         client.get_book("b1")

--- a/packages/bookshelf/tests/test_core_client.py
+++ b/packages/bookshelf/tests/test_core_client.py
@@ -6,6 +6,7 @@ from typing import Any
 import httpx
 import pytest
 
+from bookshelf._core import client as client_module
 from bookshelf._core.client import BookshelfClient
 from bookshelf._core.errors import NotFoundError, ServerError, TransportError
 from bookshelf._core.retry import RetryPolicy
@@ -14,6 +15,17 @@ from tests import _core_payloads as payloads
 
 BASE_URL = "https://bookshelf.test"
 ATTEMPTS = RetryPolicy().max_attempts
+
+
+@pytest.fixture(autouse=True)
+def no_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Take the retry backoff out of the wall clock."""
+
+    async def no_async_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(client_module.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(client_module.asyncio, "sleep", no_async_sleep)
 
 
 def make_client(handler: Any, **kwargs: Any) -> BookshelfClient:

--- a/packages/bookshelf/tests/test_core_config.py
+++ b/packages/bookshelf/tests/test_core_config.py
@@ -1,6 +1,7 @@
 """Tests for auth and base-URL resolution: explicit beats ambient, machine beats human."""
 
 import time
+from dataclasses import replace
 from datetime import UTC, datetime
 
 import httpx
@@ -129,6 +130,42 @@ def test_stored_refresh_exchange_persists_rotations(monkeypatch: pytest.MonkeyPa
         client.get("https://bookshelf.test/v1/books")
     assert saved["access_token"] == "new-tok"
     assert saved["refresh_token"] == "rt-2"
+
+
+def test_an_agent_record_without_an_assertion_rotates_as_a_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The rotation follows the provider that was built, not the record's own kind.
+
+    An agent record with no assertion is served by the refresh-token provider,
+    so what comes back is a refresh token and it has to be stored as one.
+    """
+    agent_record = replace(stored(monkeypatch), kind="agent", identity_assertion=None)
+    monkeypatch.setattr(credentials, "load_credentials", lambda _api_url=None: agent_record)
+    saved: dict[str, object] = {}
+
+    def fake_save(access_token: str, **kwargs: object) -> None:
+        saved.update(kwargs)
+
+    monkeypatch.setattr(credentials, "save_credentials", fake_save)
+    auth = config.resolve_auth(config.UNSET)
+    assert isinstance(auth, RefreshTokenExchange)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/authenticate"):
+            return httpx.Response(
+                200,
+                json={"access_token": "new-tok", "refresh_token": "rt-2", "expires_in": 3600},
+            )
+        return httpx.Response(200, json={"ok": True})
+
+    auth._expires_at = 0.0
+    with httpx.Client(transport=httpx.MockTransport(handler), auth=auth) as client:
+        client.get("https://bookshelf.test/v1/books")
+
+    assert saved["kind"] == "user"
+    assert saved["refresh_token"] == "rt-2"
+    assert "identity_assertion" not in saved
 
 
 def test_stored_without_workos_client_id_is_an_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/bookshelf/tests/test_core_frames.py
+++ b/packages/bookshelf/tests/test_core_frames.py
@@ -2,11 +2,14 @@
 
 import io
 import json
+import sys
 
 import pandas as pd
 import pandas.testing as pdt
+import pytest
 
-from bookshelf._core.frames import to_pandas
+from bookshelf._core.errors import BookshelfError
+from bookshelf._core.frames import DataFrameSupportError, require_extra, to_pandas
 from bookshelf._core.types import DataPayload
 
 
@@ -31,3 +34,17 @@ def test_json_rows_round_trip() -> None:
     content = json.dumps(_frame().to_dict(orient="records")).encode()
     result = to_pandas(DataPayload(format="json", content=content))
     pdt.assert_frame_equal(result, _frame())
+
+
+def test_a_missing_extra_is_reported_as_a_bookshelf_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller catching BookshelfError should not have to catch ImportError as well."""
+    monkeypatch.setitem(sys.modules, "pandas", None)
+
+    with pytest.raises(DataFrameSupportError) as raised:
+        require_extra("pandas", "DataFrame conversion")
+
+    assert isinstance(raised.value, BookshelfError)
+    assert "DataFrame conversion requires the 'dataframes' extra" in str(raised.value)
+    assert "pip install 'bookshelf[dataframes]'" in str(raised.value)

--- a/packages/bookshelf/tests/test_core_retry.py
+++ b/packages/bookshelf/tests/test_core_retry.py
@@ -1,7 +1,5 @@
 """Unit tests for the transient retry policy."""
 
-import random
-
 from bookshelf._core.retry import RetryPolicy
 
 
@@ -16,7 +14,6 @@ def test_retries_5xx_only() -> None:
 
 def test_delay_grows_and_is_capped() -> None:
     policy = RetryPolicy(backoff_base=1.0, backoff_cap=3.0)
-    rand = random.Random(7)
     for attempt, ceiling in ((1, 1.0), (2, 2.0), (3, 3.0), (4, 3.0)):
-        delays = [policy.delay(attempt, rand=rand) for _ in range(50)]
+        delays = [policy.delay(attempt) for _ in range(50)]
         assert all(0.0 <= delay <= ceiling for delay in delays)


### PR DESCRIPTION
Ten of the twelve seams in this package had one adapter or none. A seam with a single adapter widens the interface and invites every reader to hunt for a variation that never arrives, so this retires the ones that never earned their keep.

## What went

- `_claim_started` in `_cli/auth.py`, a hook whose body was only a docstring, with zero implementations and zero tests. A seam installed for a test that does not exist.
- `_sleep` and `_monotonic` in `_cli/auth.py`, commented as test seams but never rebound anywhere.
- `_base_url` in `_cli/auth.py` and `_client` in `_cli/discovery.py`, one-line aliases for `resolve_base_url` and the client constructor.
- The `retry` parameter on `BookshelfClient`, `Bookshelf` and `AsyncBookshelf`. `RetryPolicy` has no alternative and no subclass in the tree, so the client now holds its own.
- The `rand` parameter on `RetryPolicy.delay`. Production always took the `None` branch, and the one test that passed a seeded generator already asserts bounds rather than an exact value.
- The `cache` parameter on both facades. It only let a test pick a directory, which `ContentCache(base_dir=...)` already does.
- One of the two `on_rotate` closures in `_core/config.py`. Both wrote a rotated credential back over the record it came from, so that was one behaviour with two copies of it rather than two adapters. `_rotation_sink` now builds it once, taking the kind of the provider that was built rather than reading it off the record. That distinction matters, because an agent record with no identity assertion falls through to the refresh-token provider and has to rotate as a user.

## What stayed

- `ProduceSink` and `AsyncProduceSink`. `LiveSink` and `RecordingSink` are genuinely different, so the seam is real.
- `httpx.Auth`, with four adapters. It is httpx's seam rather than one this codebase designed, but it is a real one.
- The `on_rotate` callback itself. It is how `_core/auth.py` stays free of the credential store.
- `transport` and `async_transport`, deliberately.

## Why transport is the exception

Production always passes `None` and only tests pass a value, so by the count it looks like the others. It stays because it is the one seam the tests reach cleanly today and it is the whole basis of `test_core_client.py`, `test_facade_lifecycle.py` and `test_core_auth.py`. Deleting it would not remove complexity, it would move it into a monkeypatch. Each constructor now carries a one-line comment naming it as the test seam, so the next reader does not file it alongside the ones that just went.

## On `_sleep` and `_monotonic`

The brief asked whether removing them closes off the only route to testing the device-flow polling in `_poll_claim`, which had no test. It does not. `_poll_claim` is reachable directly with a stub client, the expiry path needs no fake clock at all (`expires_in=0`), and the waits are captured by patching `time.sleep` on the module, which is the pattern `test_oauth.py` already uses. So both names are gone and `test_cli_claim_polling.py` now covers the polling waits, the `slow_down` back-off, the hard-failure path and the expiry.

## Second defect, fixed here

`as_polars()` and `as_arrow()` imported polars and pyarrow with no guard, so an install without the `dataframes` extra raised a bare `ImportError`. Every sibling optional-extra path raises a typed error carrying an install hint (`_core/frames.py`, `_consume/conversions.py`), and these two now raise `DataFrameSupportError` in the same shape. Both are tested. This is small but it is the difference between a caller catching `BookshelfError` and not.

The same try/import/raise shape guarded all three optional imports across two modules, so `require_extra` now holds it once, next to the error it raises. That also covers the pandas path, which carried a `no cover` pragma because nothing reached it.

## Verification

`make checks` exits 0 (pre-commit all passed, mypy clean over 52 source files) and `make test` passes with 471 tests.

Targets `feat/adopt-bookshelf-sdk`, not `main`. The code being changed does not exist on `main`.

## Deliberately left out

- `kind` is still a bare `str` driving the branch in `_rotation_sink`. A two-member literal would make it checkable, but `credentials.save_credentials` types it the same way and that file is also out of scope here.
