### PR TITLE
refactor: give Bundle ownership of its own invariants

### DIFF
--- a/changelog/159.improvement.md
+++ b/changelog/159.improvement.md
@@ -1,6 +1,6 @@
-`Bundle` now owns the rules that decide whether a bundle is a replayable published book.
+Moved the rules that decide whether a bundle is a replayable published book onto `Bundle` itself.
 `Bundle.validate` asserts them and raises the new `InvalidBundleError`,
 and `Bundle.read_validated` reads and asserts in one call,
 so a caller no longer has to repeat the checks that `bookshelf validate` was making privately.
-`bookshelf validate` produces the same output and the same exit codes as before,
+`bookshelf validate` kept its output and its exit codes,
 except that a bundle whose recorded bytes are missing is now reported rather than raising through.

--- a/changelog/159.improvement.md
+++ b/changelog/159.improvement.md
@@ -1,0 +1,8 @@
+`Bundle` now owns the rules that decide whether a bundle is a replayable published book.
+
+`Bundle.validate` asserts them and raises the new `InvalidBundleError`,
+and `Bundle.read_validated` reads and asserts in one call.
+The rules previously lived in the `bookshelf validate` implementation,
+so any other caller of `Bundle` could be handed records that broke the bundle's own contract.
+
+`bookshelf validate` produces the same output and the same exit codes as before.

--- a/changelog/159.improvement.md
+++ b/changelog/159.improvement.md
@@ -1,8 +1,6 @@
 `Bundle` now owns the rules that decide whether a bundle is a replayable published book.
-
 `Bundle.validate` asserts them and raises the new `InvalidBundleError`,
-and `Bundle.read_validated` reads and asserts in one call.
-The rules previously lived in the `bookshelf validate` implementation,
-so any other caller of `Bundle` could be handed records that broke the bundle's own contract.
-
-`bookshelf validate` produces the same output and the same exit codes as before.
+and `Bundle.read_validated` reads and asserts in one call,
+so a caller no longer has to repeat the checks that `bookshelf validate` was making privately.
+`bookshelf validate` produces the same output and the same exit codes as before,
+except that a bundle whose recorded bytes are missing is now reported rather than raising through.

--- a/packages/bookshelf/src/bookshelf/_cli/producer.py
+++ b/packages/bookshelf/src/bookshelf/_cli/producer.py
@@ -36,7 +36,6 @@ from bookshelf._cli._runtime import (
 from bookshelf._core.client import BookshelfClient
 from bookshelf._core.config import resolve_base_url
 from bookshelf._core.errors import BookshelfError
-from bookshelf._core.hashing import sha256_hex
 from bookshelf._generated import models
 from bookshelf.facade import Bookshelf
 from bookshelf.publisher import (
@@ -48,7 +47,7 @@ from bookshelf.publisher import (
     replay_bundle_sync,
     run_record,
 )
-from bookshelf.publisher.bundle import BundleBook, book_data_dictionary
+from bookshelf.publisher.bundle import BundleBook, InvalidBundleError, book_data_dictionary
 
 _RECORD_REQUIREMENTS = ("papermill", "nbconvert")
 _PAGE_SIZE = 100
@@ -131,61 +130,30 @@ def _resolve_build(build: Path | None, recipe: Path) -> Path:
     return resolved
 
 
-def _read_bundle(root: Path) -> Bundle:
-    """Load a bundle directory, mapping an unreadable one onto its own exit code.
+def _read_bundle(root: Path, *, validated: bool = False) -> tuple[Bundle, BundleBook]:
+    """Load a bundle and its book framing, rendering every refusal as an invalid bundle.
 
     A malformed manifest is a distinct outcome from a crash,
     so a caller can branch on it.
     ``ValueError`` covers both the schema-major refusal
     and the pydantic validation failure.
+    ``validated`` asks the bundle for the whole replayable-published-book contract.
+    Publishing asks only for the framing,
+    because a bundle recorded as a draft replays as a draft.
     """
     try:
-        return Bundle.read(root)
+        loaded = Bundle.read_validated(root) if validated else Bundle.read(root)
+        return loaded, loaded.require_framing()
+    except InvalidBundleError as exc:
+        raise CliError(
+            f"{exc}. Run 'bookshelf record' to rebuild the bundle.",
+            exit_code=EXIT_INVALID_BUNDLE,
+        ) from exc
     except (OSError, ValueError) as exc:
         raise CliError(
             f"cannot read a bundle at {root}: {exc}. Run 'bookshelf record' to build one.",
             exit_code=EXIT_INVALID_BUNDLE,
         ) from exc
-
-
-def _invalid(message: str) -> CliError:
-    return CliError(
-        f"{message}. Run 'bookshelf record' to rebuild the bundle.",
-        exit_code=EXIT_INVALID_BUNDLE,
-    )
-
-
-def _require_framing(bundle: Bundle) -> BundleBook:
-    """Return the recorded book framing, or fail as an invalid bundle."""
-    framing = bundle.manifest.book
-    if framing is None:
-        raise _invalid("bundle has no book framing")
-    return framing
-
-
-def _check_bundle(bundle: Bundle) -> BundleBook:
-    """Assert a bundle is a replayable published book, re-hashing its managed bytes."""
-    framing = _require_framing(bundle)
-    if not framing.published:
-        raise _invalid("bundle does not record a publish operation")
-    if not framing.entries:
-        raise _invalid("bundle has no book entries")
-
-    resources = {resource.tracking_id for resource in bundle.manifest.resources}
-    for entry in framing.entries:
-        if entry.tracking_id not in resources:
-            raise _invalid(f"book entry {entry.name_in_book!r} has no resource")
-
-    for resource in bundle.manifest.resources:
-        if resource.kind != "managed":
-            continue
-        actual = sha256_hex(bundle.resource_bytes(resource))
-        if actual != resource.hash:
-            raise _invalid(
-                f"resource {resource.tracking_id} has hash {resource.hash}, got {actual}"
-            )
-
-    return framing
 
 
 def _emit_summary(summary: dict[str, Any], labels: dict[str, str], *, json_output: bool) -> None:
@@ -264,8 +232,7 @@ def validate(
 ) -> None:
     """Assert a recorded bundle is a replayable published book, and hash it."""
     with command_errors():
-        loaded = _read_bundle(bundle)
-        framing = _check_bundle(loaded)
+        loaded, framing = _read_bundle(bundle, validated=True)
         summary = {
             "bundle_path": str(bundle),
             "bundle_hash": compute_book_bundle_hash(loaded.manifest),
@@ -290,8 +257,7 @@ def publish(
     # Credentials resolve through the usual chain, so there is no token flag
     # to leave a secret in a process list or a CI log.
     with command_errors():
-        loaded = _read_bundle(bundle)
-        framing = _require_framing(loaded)
+        loaded, framing = _read_bundle(bundle)
         bundle_hash = compute_book_bundle_hash(loaded.manifest)
 
         with Bookshelf(resolve_base_url(api_url)) as client:

--- a/packages/bookshelf/src/bookshelf/_cli/producer.py
+++ b/packages/bookshelf/src/bookshelf/_cli/producer.py
@@ -134,7 +134,7 @@ def _resolve_build(build: Path | None, recipe: Path) -> Path:
 
 @contextmanager
 def _bundle_errors(root: Path) -> Generator[None]:
-    """Render a bundle that refuses itself, and one that will not load at all.
+    """Map a bundle that refuses itself, and one that will not load, onto the invalid-bundle code.
 
     A malformed manifest is a distinct outcome from a crash,
     so a caller can branch on it.

--- a/packages/bookshelf/src/bookshelf/_cli/producer.py
+++ b/packages/bookshelf/src/bookshelf/_cli/producer.py
@@ -15,6 +15,8 @@ so an abandoned attempt leaves an edition behind until it is deleted.
 """
 
 import importlib.util
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -47,7 +49,7 @@ from bookshelf.publisher import (
     replay_bundle_sync,
     run_record,
 )
-from bookshelf.publisher.bundle import BundleBook, InvalidBundleError, book_data_dictionary
+from bookshelf.publisher.bundle import InvalidBundleError, book_data_dictionary
 
 _RECORD_REQUIREMENTS = ("papermill", "nbconvert")
 _PAGE_SIZE = 100
@@ -130,20 +132,17 @@ def _resolve_build(build: Path | None, recipe: Path) -> Path:
     return resolved
 
 
-def _read_bundle(root: Path, *, validated: bool = False) -> tuple[Bundle, BundleBook]:
-    """Load a bundle and its book framing, rendering every refusal as an invalid bundle.
+@contextmanager
+def _bundle_errors(root: Path) -> Generator[None]:
+    """Render a bundle that refuses itself, and one that will not load at all.
 
     A malformed manifest is a distinct outcome from a crash,
     so a caller can branch on it.
     ``ValueError`` covers both the schema-major refusal
     and the pydantic validation failure.
-    ``validated`` asks the bundle for the whole replayable-published-book contract.
-    Publishing asks only for the framing,
-    because a bundle recorded as a draft replays as a draft.
     """
     try:
-        loaded = Bundle.read_validated(root) if validated else Bundle.read(root)
-        return loaded, loaded.require_framing()
+        yield
     except InvalidBundleError as exc:
         raise CliError(
             f"{exc}. Run 'bookshelf record' to rebuild the bundle.",
@@ -232,7 +231,9 @@ def validate(
 ) -> None:
     """Assert a recorded bundle is a replayable published book, and hash it."""
     with command_errors():
-        loaded, framing = _read_bundle(bundle, validated=True)
+        with _bundle_errors(bundle):
+            loaded = Bundle.read_validated(bundle)
+            framing = loaded.require_framing()
         summary = {
             "bundle_path": str(bundle),
             "bundle_hash": compute_book_bundle_hash(loaded.manifest),
@@ -257,7 +258,11 @@ def publish(
     # Credentials resolve through the usual chain, so there is no token flag
     # to leave a secret in a process list or a CI log.
     with command_errors():
-        loaded, framing = _read_bundle(bundle)
+        # Publishing asks only for the framing,
+        # because a bundle recorded as a draft replays as a draft.
+        with _bundle_errors(bundle):
+            loaded = Bundle.read(bundle)
+            framing = loaded.require_framing()
         bundle_hash = compute_book_bundle_hash(loaded.manifest)
 
         with Bookshelf(resolve_base_url(api_url)) as client:

--- a/packages/bookshelf/src/bookshelf/publisher/bundle.py
+++ b/packages/bookshelf/src/bookshelf/publisher/bundle.py
@@ -60,6 +60,14 @@ Within the supported major,
 the reader tolerates unknown fields from a newer minor version.
 A newer major version is refused rather than reinterpreted.
 
+Validation
+----------
+The rules that decide whether a bundle is a replayable published book live here,
+because the bundle already holds everything they need:
+the manifest, the recorded bytes, and the hash of each.
+:meth:`Bundle.validate` asserts them and raises :class:`InvalidBundleError`,
+so every caller refuses the same bundles for the same reasons.
+
 Serialisation reuses :func:`~bookshelf.publisher.lock._dump_sorted_yaml`.
 The manifest therefore has the same on-disk shape as ``bookshelf.lock``.
 It uses sorted keys,
@@ -78,6 +86,7 @@ from uuid import UUID
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from bookshelf._core.errors import BookshelfError
 from bookshelf._core.hashing import canonical_json_bytes, sha256_hex
 from bookshelf._generated import models
 from bookshelf.publisher.lock import _dump_sorted_yaml
@@ -104,6 +113,17 @@ _PARQUET_TYPES = frozenset({"timeseries", "tabular"})
 # with no ``:``, ``/``, or ``.`` characters.
 # A crafted manifest hash therefore cannot traverse out of ``resources/``.
 _SHA256_RE = re.compile(r"^sha256:([0-9a-f]{64})$")
+
+
+class InvalidBundleError(BookshelfError):
+    """A bundle on disk breaks the contract a bundle promises.
+
+    The message names the invariant that failed
+    and carries the detail a caller needs to render it.
+    It is raised by :meth:`Bundle.validate`,
+    so a caller either holds a bundle that keeps its contract
+    or holds an error explaining why it does not.
+    """
 
 
 def _sha256_hex(hash_: str) -> str:
@@ -229,7 +249,7 @@ class BundleResource(BaseModel):
 class BundleActivity(BaseModel):
     """The activity envelope recorded in the bundle manifest.
 
-    Mirrors the wire :class:`~bookshelf.publisher._models.ActivityCreate`,
+    Mirrors the wire :class:`~bookshelf._generated.models.ActivityEnvelope`,
     minus build-level ``used`` references,
     which are recorded per resource.
     It contains the client-minted ``activity_id``
@@ -463,6 +483,13 @@ class Bundle:
     and appends a manifest record.
     :meth:`write` flushes the manifest.
     :meth:`read` loads an existing bundle.
+
+    A bundle also owns the rules that decide whether it is a replayable published book.
+    :meth:`validate` asserts the whole contract,
+    :meth:`require_framing` asserts the framing alone,
+    and :meth:`read_validated` reads and asserts in one call.
+    Each raises :class:`InvalidBundleError`,
+    so a caller never has to rediscover a rule the bundle already knows.
     """
 
     def __init__(self, root: Path, manifest: BundleManifest | None = None) -> None:
@@ -662,6 +689,53 @@ class Bundle:
         byte_path = self.resources_dir / resource_filename(record.hash, record.type)
         return byte_path.read_bytes()
 
+    def require_framing(self) -> BundleBook:
+        """Return the recorded book framing, or raise :class:`InvalidBundleError`.
+
+        A resources-only bundle records no book,
+        so replay has nothing to draft.
+        """
+        if self.manifest.book is None:
+            raise InvalidBundleError("bundle has no book framing")
+        return self.manifest.book
+
+    def validate(self) -> BundleBook:
+        """Assert this bundle is a replayable published book, and return its framing.
+
+        The contract is:
+
+        - the bundle records a book framing
+        - that book is marked for publication
+        - the book has at least one entry
+        - every entry references a resource recorded in the same manifest
+        - every managed resource's bytes still hash to the recorded hash
+
+        The bytes are re-hashed rather than trusted,
+        so a bundle edited between record and replay is refused here
+        instead of publishing content that no reviewer saw.
+        Raises :class:`InvalidBundleError` naming the first invariant that fails.
+        """
+        framing = self.require_framing()
+        if not framing.published:
+            raise InvalidBundleError("bundle does not record a publish operation")
+        if not framing.entries:
+            raise InvalidBundleError("bundle has no book entries")
+
+        recorded = {resource.tracking_id for resource in self.manifest.resources}
+        for entry in framing.entries:
+            if entry.tracking_id not in recorded:
+                raise InvalidBundleError(f"book entry {entry.name_in_book!r} has no resource")
+
+        for resource in self.manifest.resources:
+            if resource.kind != "managed":
+                continue
+            actual = sha256_hex(self.resource_bytes(resource))
+            if actual != resource.hash:
+                raise InvalidBundleError(
+                    f"resource {resource.tracking_id} has hash {resource.hash}, got {actual}"
+                )
+        return framing
+
     def write(self) -> None:
         """Flush the manifest to ``manifest.lock`` (deterministic YAML)."""
         self.root.mkdir(parents=True, exist_ok=True)
@@ -677,11 +751,26 @@ class Bundle:
         and keeps only the fields this schema models.
         A newer major raises :class:`ValueError`
         instead of being reinterpreted under the current semantics.
+
+        The read is structural.
+        A bundle recorded as a draft loads here and replays as a draft,
+        so use :meth:`read_validated` when the caller needs a published book.
         """
         raw: dict[str, Any] = yaml.safe_load((root / MANIFEST_NAME).read_bytes()) or {}
         _check_schema_major(raw)
         manifest = BundleManifest.model_validate(raw)
         return cls(root=root, manifest=manifest)
+
+    @classmethod
+    def read_validated(cls, root: Path) -> Bundle:
+        """Load a bundle directory and assert its contract in one call.
+
+        Raises whatever :meth:`read` raises for an unreadable manifest,
+        and :class:`InvalidBundleError` for a bundle that is not a replayable published book.
+        """
+        bundle = cls.read(root)
+        bundle.validate()
+        return bundle
 
 
 __all__ = [
@@ -695,6 +784,7 @@ __all__ = [
     "BundleManifest",
     "BundleResource",
     "BundleUsedRef",
+    "InvalidBundleError",
     "compute_book_bundle_hash",
     "resource_filename",
     "synthesise_pointer_hash",

--- a/packages/bookshelf/src/bookshelf/publisher/bundle.py
+++ b/packages/bookshelf/src/bookshelf/publisher/bundle.py
@@ -708,7 +708,7 @@ class Bundle:
         - that book is marked for publication
         - the book has at least one entry
         - every entry references a resource recorded in the same manifest
-        - every managed resource's bytes still hash to the recorded hash
+        - every managed resource's bytes are present and still hash to the recorded hash
 
         The bytes are re-hashed rather than trusted,
         so a bundle edited between record and replay is refused here
@@ -729,7 +729,13 @@ class Bundle:
         for resource in self.manifest.resources:
             if resource.kind != "managed":
                 continue
-            actual = sha256_hex(self.resource_bytes(resource))
+            try:
+                data = self.resource_bytes(resource)
+            except OSError as exc:
+                raise InvalidBundleError(
+                    f"resource {resource.tracking_id} has no bytes in the bundle: {exc}"
+                ) from exc
+            actual = sha256_hex(data)
             if actual != resource.hash:
                 raise InvalidBundleError(
                     f"resource {resource.tracking_id} has hash {resource.hash}, got {actual}"
@@ -753,8 +759,7 @@ class Bundle:
         instead of being reinterpreted under the current semantics.
 
         The read is structural.
-        A bundle recorded as a draft loads here and replays as a draft,
-        so use :meth:`read_validated` when the caller needs a published book.
+        A bundle recorded as a draft loads here and replays as a draft.
         """
         raw: dict[str, Any] = yaml.safe_load((root / MANIFEST_NAME).read_bytes()) or {}
         _check_schema_major(raw)

--- a/packages/bookshelf/src/bookshelf/publisher/bundle.py
+++ b/packages/bookshelf/src/bookshelf/publisher/bundle.py
@@ -120,8 +120,7 @@ class InvalidBundleError(BookshelfError):
 
     The message names the invariant that failed
     and carries the detail a caller needs to render it.
-    It is raised by :meth:`Bundle.validate`,
-    so a caller either holds a bundle that keeps its contract
+    A caller therefore either holds a bundle that keeps its contract
     or holds an error explaining why it does not.
     """
 
@@ -699,8 +698,8 @@ class Bundle:
             raise InvalidBundleError("bundle has no book framing")
         return self.manifest.book
 
-    def validate(self) -> BundleBook:
-        """Assert this bundle is a replayable published book, and return its framing.
+    def validate(self) -> None:
+        """Assert this bundle is a replayable published book.
 
         The contract is:
 
@@ -708,7 +707,8 @@ class Bundle:
         - that book is marked for publication
         - the book has at least one entry
         - every entry references a resource recorded in the same manifest
-        - every managed resource's bytes are present and still hash to the recorded hash
+        - every managed resource's bytes are present and still hash to the recorded hash,
+          which a non-canonical hash cannot satisfy because it names no byte file
 
         The bytes are re-hashed rather than trusted,
         so a bundle edited between record and replay is refused here
@@ -731,6 +731,10 @@ class Bundle:
                 continue
             try:
                 data = self.resource_bytes(resource)
+            except ValueError as exc:
+                raise InvalidBundleError(
+                    f"resource {resource.tracking_id} has a non-canonical hash {resource.hash!r}"
+                ) from exc
             except OSError as exc:
                 raise InvalidBundleError(
                     f"resource {resource.tracking_id} has no bytes in the bundle: {exc}"
@@ -740,7 +744,6 @@ class Bundle:
                 raise InvalidBundleError(
                     f"resource {resource.tracking_id} has hash {resource.hash}, got {actual}"
                 )
-        return framing
 
     def write(self) -> None:
         """Flush the manifest to ``manifest.lock`` (deterministic YAML)."""

--- a/packages/bookshelf/tests/conftest.py
+++ b/packages/bookshelf/tests/conftest.py
@@ -11,11 +11,10 @@ from bookshelf.publisher.bundle import Bundle, BundleBook
 
 
 class BundleFactory(Protocol):
-    """Builds a bundle on disk and returns it."""
+    """Builds a bundle under ``tmp_path`` and returns it."""
 
     def __call__(
         self,
-        root: Path | None = None,
         *,
         published: bool = True,
         entries: int = 1,
@@ -32,13 +31,12 @@ def make_bundle(tmp_path: Path) -> BundleFactory:
     """
 
     def factory(
-        root: Path | None = None,
         *,
         published: bool = True,
         entries: int = 1,
         book: BundleBook | None = None,
     ) -> Bundle:
-        bundle = Bundle(root if root is not None else tmp_path / "bundle")
+        bundle = Bundle(tmp_path / "bundle")
         bundle.set_book(
             book
             if book is not None

--- a/packages/bookshelf/tests/conftest.py
+++ b/packages/bookshelf/tests/conftest.py
@@ -1,0 +1,61 @@
+"""Fixtures shared across the test suite."""
+
+from pathlib import Path
+from typing import Protocol
+from uuid import uuid4
+
+import pytest
+
+from bookshelf._core.hashing import sha256_hex
+from bookshelf.publisher.bundle import Bundle, BundleBook
+
+
+class BundleFactory(Protocol):
+    """Builds a bundle on disk and returns it."""
+
+    def __call__(
+        self,
+        root: Path | None = None,
+        *,
+        published: bool = True,
+        entries: int = 1,
+        book: BundleBook | None = None,
+    ) -> Bundle: ...
+
+
+@pytest.fixture
+def make_bundle(tmp_path: Path) -> BundleFactory:
+    """Return a factory for a written bundle that satisfies the whole bundle contract.
+
+    ``published``, ``entries`` and ``book`` each relax one part of it,
+    so a test can name the single invariant it is about.
+    """
+
+    def factory(
+        root: Path | None = None,
+        *,
+        published: bool = True,
+        entries: int = 1,
+        book: BundleBook | None = None,
+    ) -> Bundle:
+        bundle = Bundle(root if root is not None else tmp_path / "bundle")
+        bundle.set_book(
+            book
+            if book is not None
+            else BundleBook(volume="example", version="v1.0.0", visibility="public", license="MIT")
+        )
+        for index in range(entries):
+            data = f"payload {index}".encode()
+            resource = bundle.add_resource(
+                data=data,
+                hash_=sha256_hex(data),
+                type_="document",
+                tracking_id=uuid4(),
+            )
+            bundle.add_book_entry(name_in_book=f"entry-{index}", tracking_id=resource.tracking_id)
+        if published:
+            bundle.mark_book_published()
+        bundle.write()
+        return bundle
+
+    return factory

--- a/packages/bookshelf/tests/conftest.py
+++ b/packages/bookshelf/tests/conftest.py
@@ -28,7 +28,12 @@ def make_bundle(tmp_path: Path) -> BundleFactory:
 
     ``published``, ``entries`` and ``book`` each relax one part of it,
     so a test can name the single invariant it is about.
+    The first bundle lands at ``tmp_path / "bundle"``,
+    which is the directory the CLI defaults to.
+    Each later one takes its own directory,
+    so two bundles in one test never share a ``resources/``.
     """
+    made = 0
 
     def factory(
         *,
@@ -36,7 +41,9 @@ def make_bundle(tmp_path: Path) -> BundleFactory:
         entries: int = 1,
         book: BundleBook | None = None,
     ) -> Bundle:
-        bundle = Bundle(tmp_path / "bundle")
+        nonlocal made
+        bundle = Bundle(tmp_path / (f"bundle-{made}" if made else "bundle"))
+        made += 1
         bundle.set_book(
             book
             if book is not None

--- a/packages/bookshelf/tests/test_bundle.py
+++ b/packages/bookshelf/tests/test_bundle.py
@@ -1,0 +1,147 @@
+"""Tests for the bundle contract, through the :class:`Bundle` interface."""
+
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from bookshelf._core.errors import BookshelfError
+from bookshelf.publisher.bundle import (
+    Bundle,
+    BundleBook,
+    InvalidBundleError,
+    resource_filename,
+    synthesise_pointer_hash,
+)
+from tests.conftest import BundleFactory
+
+
+def test_a_recorded_published_book_validates(make_bundle: BundleFactory) -> None:
+    bundle = make_bundle(entries=2)
+
+    framing = bundle.validate()
+
+    assert framing.volume == "example"
+    assert len(framing.entries) == 2
+
+
+def test_a_bundle_with_no_book_framing_is_invalid(tmp_path: Path) -> None:
+    bundle = Bundle(tmp_path / "bundle")
+
+    with pytest.raises(InvalidBundleError, match="no book framing"):
+        bundle.validate()
+
+
+def test_a_bundle_that_is_still_a_draft_is_invalid(make_bundle: BundleFactory) -> None:
+    bundle = make_bundle(published=False)
+
+    with pytest.raises(InvalidBundleError, match="does not record a publish operation"):
+        bundle.validate()
+
+
+def test_a_book_with_no_entries_is_invalid(make_bundle: BundleFactory) -> None:
+    bundle = make_bundle(entries=0)
+
+    with pytest.raises(InvalidBundleError, match="no book entries"):
+        bundle.validate()
+
+
+def test_an_entry_without_its_resource_is_invalid(make_bundle: BundleFactory) -> None:
+    bundle = make_bundle()
+    bundle.manifest.book.entries[0].tracking_id = uuid4()  # type: ignore[union-attr]
+
+    with pytest.raises(InvalidBundleError, match="book entry 'entry-0' has no resource"):
+        bundle.validate()
+
+
+def test_managed_bytes_are_re_hashed_against_the_manifest(make_bundle: BundleFactory) -> None:
+    """A bundle edited after recording must not publish content no reviewer saw."""
+    bundle = make_bundle()
+    resource = bundle.manifest.resources[0]
+    (bundle.resources_dir / resource_filename(resource.hash, resource.type)).write_bytes(
+        b"tampered"
+    )
+
+    with pytest.raises(InvalidBundleError) as raised:
+        bundle.validate()
+
+    assert f"resource {resource.tracking_id} has hash {resource.hash}, got sha256:" in str(
+        raised.value
+    )
+
+
+def test_a_pointer_is_not_re_hashed(tmp_path: Path) -> None:
+    """A pointer has no byte file, so hashing one would fail on a valid bundle."""
+    bundle = Bundle(tmp_path / "bundle")
+    bundle.set_book(BundleBook(volume="example", version="v1.0.0"))
+    pointer = bundle.add_pointer(
+        external_uri="https://example.invalid/data.csv",
+        hash_=synthesise_pointer_hash(
+            type_="tabular", external_uri="https://example.invalid/data.csv"
+        ),
+        type_="tabular",
+        tracking_id=uuid4(),
+    )
+    bundle.add_book_entry(name_in_book="entry-0", tracking_id=pointer.tracking_id)
+    bundle.mark_book_published()
+
+    assert bundle.validate().entries[0].name_in_book == "entry-0"
+
+
+def test_require_framing_returns_the_recorded_book(make_bundle: BundleFactory) -> None:
+    bundle = make_bundle()
+
+    assert bundle.require_framing().version == "v1.0.0"
+
+
+def test_require_framing_refuses_a_resources_only_bundle(tmp_path: Path) -> None:
+    with pytest.raises(InvalidBundleError, match="no book framing"):
+        Bundle(tmp_path / "bundle").require_framing()
+
+
+def test_read_validated_returns_a_bundle_that_keeps_its_contract(
+    make_bundle: BundleFactory,
+) -> None:
+    written = make_bundle(entries=2)
+
+    loaded = Bundle.read_validated(written.root)
+
+    assert len(loaded.manifest.resources) == 2
+
+
+def test_read_validated_refuses_a_bundle_tampered_with_on_disk(
+    make_bundle: BundleFactory,
+) -> None:
+    written = make_bundle()
+    resource = written.manifest.resources[0]
+    (written.resources_dir / resource_filename(resource.hash, resource.type)).write_bytes(
+        b"tampered"
+    )
+
+    with pytest.raises(InvalidBundleError, match="has hash"):
+        Bundle.read_validated(written.root)
+
+
+def test_read_leaves_a_draft_loadable(make_bundle: BundleFactory) -> None:
+    """Replay keeps the unvalidated read, because a bundle recorded as a draft replays as one."""
+    written = make_bundle(published=False)
+
+    loaded = Bundle.read(written.root)
+
+    assert loaded.require_framing().published is False
+
+
+def test_tracking_ids_round_trip_as_uuids(make_bundle: BundleFactory) -> None:
+    written = make_bundle()
+
+    reloaded = Bundle.read(written.root)
+
+    assert isinstance(reloaded.manifest.resources[0].tracking_id, UUID)
+
+
+def test_an_invalid_bundle_is_a_bookshelf_error(make_bundle: BundleFactory) -> None:
+    """One catch reaches every bundle refusal, so a caller never enumerates the rules."""
+    bundle = make_bundle(published=False)
+
+    with pytest.raises(BookshelfError):
+        bundle.validate()

--- a/packages/bookshelf/tests/test_bundle.py
+++ b/packages/bookshelf/tests/test_bundle.py
@@ -70,6 +70,16 @@ def test_managed_bytes_are_re_hashed_against_the_manifest(make_bundle: BundleFac
     )
 
 
+def test_a_managed_resource_with_no_bytes_is_invalid(make_bundle: BundleFactory) -> None:
+    """A manifest record whose byte file is gone is a refusal, not a crash."""
+    bundle = make_bundle()
+    resource = bundle.manifest.resources[0]
+    (bundle.resources_dir / resource_filename(resource.hash, resource.type)).unlink()
+
+    with pytest.raises(InvalidBundleError, match="has no bytes in the bundle"):
+        bundle.validate()
+
+
 def test_a_pointer_is_not_re_hashed(tmp_path: Path) -> None:
     """A pointer has no byte file, so hashing one would fail on a valid bundle."""
     bundle = Bundle(tmp_path / "bundle")

--- a/packages/bookshelf/tests/test_bundle.py
+++ b/packages/bookshelf/tests/test_bundle.py
@@ -19,10 +19,10 @@ from tests.conftest import BundleFactory
 def test_a_recorded_published_book_validates(make_bundle: BundleFactory) -> None:
     bundle = make_bundle(entries=2)
 
-    framing = bundle.validate()
+    bundle.validate()
 
-    assert framing.volume == "example"
-    assert len(framing.entries) == 2
+    assert bundle.require_framing().volume == "example"
+    assert len(bundle.require_framing().entries) == 2
 
 
 def test_a_bundle_with_no_book_framing_is_invalid(tmp_path: Path) -> None:
@@ -80,6 +80,15 @@ def test_a_managed_resource_with_no_bytes_is_invalid(make_bundle: BundleFactory)
         bundle.validate()
 
 
+def test_a_crafted_hash_is_invalid_rather_than_unreadable(make_bundle: BundleFactory) -> None:
+    """A hash that names no byte file is a refusal, not an attempt to read a traversed path."""
+    bundle = make_bundle()
+    bundle.manifest.resources[0].hash = "sha256:../../etc/passwd"
+
+    with pytest.raises(InvalidBundleError, match="non-canonical hash"):
+        bundle.validate()
+
+
 def test_a_pointer_is_not_re_hashed(tmp_path: Path) -> None:
     """A pointer has no byte file, so hashing one would fail on a valid bundle."""
     bundle = Bundle(tmp_path / "bundle")
@@ -95,7 +104,7 @@ def test_a_pointer_is_not_re_hashed(tmp_path: Path) -> None:
     bundle.add_book_entry(name_in_book="entry-0", tracking_id=pointer.tracking_id)
     bundle.mark_book_published()
 
-    assert bundle.validate().entries[0].name_in_book == "entry-0"
+    bundle.validate()
 
 
 def test_require_framing_returns_the_recorded_book(make_bundle: BundleFactory) -> None:

--- a/packages/bookshelf/tests/test_cli_producer.py
+++ b/packages/bookshelf/tests/test_cli_producer.py
@@ -18,7 +18,12 @@ from bookshelf._cli._runtime import (
     EXIT_USAGE,
 )
 from bookshelf._core.client import BookshelfClient
-from bookshelf.publisher.bundle import Bundle, BundleBook, compute_book_bundle_hash
+from bookshelf.publisher.bundle import (
+    Bundle,
+    BundleBook,
+    compute_book_bundle_hash,
+    resource_filename,
+)
 from tests import _core_payloads as payloads
 from tests.conftest import BundleFactory
 
@@ -94,6 +99,20 @@ def test_validate_renders_a_refused_bundle_with_its_remedy(make_bundle: BundleFa
     assert result.exit_code == EXIT_INVALID_BUNDLE
     assert "does not record a publish operation" in _plain(result.stderr)
     assert "bookshelf record" in _plain(result.stderr)
+
+
+def test_validate_reports_absent_resource_bytes_as_an_invalid_bundle(
+    make_bundle: BundleFactory,
+) -> None:
+    """A manifest record whose byte file is gone exits 7 rather than raising through."""
+    bundle = make_bundle()
+    resource = bundle.manifest.resources[0]
+    (bundle.resources_dir / resource_filename(resource.hash, resource.type)).unlink()
+
+    result = runner.invoke(app, ["validate", str(bundle.root)])
+
+    assert result.exit_code == EXIT_INVALID_BUNDLE
+    assert "has no bytes in the bundle" in _plain(result.stderr)
 
 
 def test_validate_rejects_a_missing_bundle(tmp_path: Path) -> None:

--- a/packages/bookshelf/tests/test_cli_producer.py
+++ b/packages/bookshelf/tests/test_cli_producer.py
@@ -115,6 +115,19 @@ def test_validate_reports_absent_resource_bytes_as_an_invalid_bundle(
     assert "has no bytes in the bundle" in _plain(result.stderr)
 
 
+def test_validate_reports_a_crafted_hash_as_an_invalid_bundle(make_bundle: BundleFactory) -> None:
+    """The manifest read fine, so the refusal must not be rendered as an unreadable bundle."""
+    bundle = make_bundle()
+    bundle.manifest.resources[0].hash = "sha256:../../etc/passwd"
+    bundle.write()
+
+    result = runner.invoke(app, ["validate", str(bundle.root)])
+
+    assert result.exit_code == EXIT_INVALID_BUNDLE
+    assert "non-canonical hash" in _plain(result.stderr)
+    assert "cannot read a bundle" not in _plain(result.stderr)
+
+
 def test_validate_rejects_a_missing_bundle(tmp_path: Path) -> None:
     result = runner.invoke(app, ["validate", str(tmp_path / "absent")])
 

--- a/packages/bookshelf/tests/test_cli_producer.py
+++ b/packages/bookshelf/tests/test_cli_producer.py
@@ -4,7 +4,6 @@ import json
 import re
 from pathlib import Path
 from typing import Any
-from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -19,39 +18,13 @@ from bookshelf._cli._runtime import (
     EXIT_USAGE,
 )
 from bookshelf._core.client import BookshelfClient
-from bookshelf._core.hashing import sha256_hex
-from bookshelf.publisher.bundle import (
-    Bundle,
-    BundleBook,
-    compute_book_bundle_hash,
-    resource_filename,
-)
+from bookshelf.publisher.bundle import Bundle, BundleBook, compute_book_bundle_hash
 from tests import _core_payloads as payloads
+from tests.conftest import BundleFactory
 
 _ANSI = re.compile(r"\x1b\[[0-9;]*m")
 UNREACHABLE_API = "http://127.0.0.1:9"
 runner = CliRunner()
-
-
-def _bundle(root: Path, *, published: bool = True, entries: int = 1) -> Bundle:
-    """Write a minimal replayable published book bundle to ``root``."""
-    bundle = Bundle(root)
-    bundle.set_book(
-        BundleBook(volume="example", version="v1.0.0", visibility="public", license="MIT")
-    )
-    for index in range(entries):
-        data = f"payload {index}".encode()
-        resource = bundle.add_resource(
-            data=data,
-            hash_=sha256_hex(data),
-            type_="document",
-            tracking_id=uuid4(),
-        )
-        bundle.add_book_entry(name_in_book=f"entry-{index}", tracking_id=resource.tracking_id)
-    if published:
-        bundle.mark_book_published()
-    bundle.write()
-    return bundle
 
 
 def _recipe(path: Path, *, notebook: str | None = "build.py") -> Path:
@@ -72,8 +45,8 @@ def _plain(text: str) -> str:
     return _ANSI.sub("", text)
 
 
-def test_validate_reports_the_bundle_summary(tmp_path: Path) -> None:
-    bundle = _bundle(tmp_path / "bundle", entries=2)
+def test_validate_reports_the_bundle_summary(make_bundle: BundleFactory) -> None:
+    bundle = make_bundle(entries=2)
     # Recomputed from what landed on disk, so the reported hash is checked
     # against an independent value rather than against itself.
     expected_hash = compute_book_bundle_hash(Bundle.read(bundle.root).manifest)
@@ -90,8 +63,8 @@ def test_validate_reports_the_bundle_summary(tmp_path: Path) -> None:
     }
 
 
-def test_validate_human_output_names_every_field(tmp_path: Path) -> None:
-    bundle = _bundle(tmp_path / "bundle")
+def test_validate_human_output_names_every_field(make_bundle: BundleFactory) -> None:
+    bundle = make_bundle()
 
     result = runner.invoke(app, ["validate", str(bundle.root)])
 
@@ -101,9 +74,9 @@ def test_validate_human_output_names_every_field(tmp_path: Path) -> None:
 
 
 def test_validate_defaults_to_the_bundle_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _bundle(tmp_path / "bundle")
+    make_bundle()
     monkeypatch.chdir(tmp_path)
 
     result = runner.invoke(app, ["validate", "--json"])
@@ -112,47 +85,15 @@ def test_validate_defaults_to_the_bundle_directory(
     assert _payload(result.stdout)["bundle_path"] == "bundle"
 
 
-def test_validate_rejects_a_bundle_that_is_still_a_draft(tmp_path: Path) -> None:
-    bundle = _bundle(tmp_path / "bundle", published=False)
+def test_validate_renders_a_refused_bundle_with_its_remedy(make_bundle: BundleFactory) -> None:
+    """The bundle names the invariant, and the CLI adds the exit code and the fix."""
+    bundle = make_bundle(published=False)
 
     result = runner.invoke(app, ["validate", str(bundle.root)])
 
     assert result.exit_code == EXIT_INVALID_BUNDLE
     assert "does not record a publish operation" in _plain(result.stderr)
     assert "bookshelf record" in _plain(result.stderr)
-
-
-def test_validate_rejects_a_bundle_with_no_book_framing(tmp_path: Path) -> None:
-    bundle = Bundle(tmp_path / "bundle")
-    bundle.write()
-
-    result = runner.invoke(app, ["validate", str(bundle.root)])
-
-    assert result.exit_code == EXIT_INVALID_BUNDLE
-    assert "no book framing" in _plain(result.stderr)
-
-
-def test_validate_rejects_tampered_resource_bytes(tmp_path: Path) -> None:
-    bundle = _bundle(tmp_path / "bundle")
-    resource = bundle.manifest.resources[0]
-    byte_path = bundle.resources_dir / resource_filename(resource.hash, resource.type)
-    byte_path.write_bytes(b"tampered")
-
-    result = runner.invoke(app, ["validate", str(bundle.root)])
-
-    assert result.exit_code == EXIT_INVALID_BUNDLE
-    assert "has hash" in _plain(result.stderr)
-
-
-def test_validate_rejects_an_entry_with_no_resource(tmp_path: Path) -> None:
-    bundle = _bundle(tmp_path / "bundle")
-    bundle.manifest.book.entries[0].tracking_id = uuid4()  # type: ignore[union-attr]
-    bundle.write()
-
-    result = runner.invoke(app, ["validate", str(bundle.root)])
-
-    assert result.exit_code == EXIT_INVALID_BUNDLE
-    assert "has no resource" in _plain(result.stderr)
 
 
 def test_validate_rejects_a_missing_bundle(tmp_path: Path) -> None:
@@ -172,8 +113,10 @@ def test_validate_rejects_a_malformed_manifest(tmp_path: Path) -> None:
     assert result.exit_code == EXIT_INVALID_BUNDLE
 
 
-def test_validate_opens_no_socket(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    bundle = _bundle(tmp_path / "bundle")
+def test_validate_opens_no_socket(
+    make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = make_bundle()
     monkeypatch.setenv("BOOKSHELF_URL", UNREACHABLE_API)
 
     result = runner.invoke(app, ["validate", str(bundle.root), "--json"])
@@ -182,9 +125,9 @@ def test_validate_opens_no_socket(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
 
 
 def test_validate_runs_without_the_publish_extra(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    bundle = _bundle(tmp_path / "bundle")
+    bundle = make_bundle()
     monkeypatch.setattr("bookshelf._cli.producer.importlib.util.find_spec", lambda _: None)
 
     result = runner.invoke(app, ["validate", str(bundle.root), "--json"])
@@ -550,9 +493,9 @@ def _patch_publish(
 
 
 def test_publish_replays_and_reports_the_edition(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    bundle = _bundle(tmp_path / "bundle")
+    bundle = make_bundle()
     client = _FakeClient(status="draft")
     replayed = _patch_publish(monkeypatch, client, edition=2)
 
@@ -570,9 +513,9 @@ def test_publish_replays_and_reports_the_edition(
 
 
 def test_publish_reports_a_no_op_when_the_edition_exists(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    bundle = _bundle(tmp_path / "bundle")
+    bundle = make_bundle()
     client = _FakeClient(status="published", edition=3)
     replayed = _patch_publish(monkeypatch, client)
 
@@ -586,8 +529,10 @@ def test_publish_reports_a_no_op_when_the_edition_exists(
     assert replayed == []
 
 
-def test_publish_dry_run_never_replays(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    bundle = _bundle(tmp_path / "bundle")
+def test_publish_dry_run_never_replays(
+    make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bundle = make_bundle()
     client = _FakeClient(status="draft", edition=1)
     replayed = _patch_publish(monkeypatch, client)
 
@@ -601,9 +546,9 @@ def test_publish_dry_run_never_replays(tmp_path: Path, monkeypatch: pytest.Monke
 
 
 def test_publish_dry_run_reports_a_no_op_for_a_published_edition(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    bundle = _bundle(tmp_path / "bundle")
+    bundle = make_bundle()
     client = _FakeClient(status="published", edition=4)
     _patch_publish(monkeypatch, client)
 
@@ -614,9 +559,9 @@ def test_publish_dry_run_reports_a_no_op_for_a_published_edition(
 
 
 def test_publish_forwards_the_recorded_framing_to_the_draft(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    bundle = _bundle(tmp_path / "bundle")
+    bundle = make_bundle()
     client = _FakeClient(status="draft")
     _patch_publish(monkeypatch, client)
 
@@ -629,8 +574,8 @@ def test_publish_forwards_the_recorded_framing_to_the_draft(
     assert client.draft_kwargs["license"] == "MIT"
 
 
-def test_publish_rejects_a_token_flag(tmp_path: Path) -> None:
-    bundle = _bundle(tmp_path / "bundle")
+def test_publish_rejects_a_token_flag(make_bundle: BundleFactory) -> None:
+    bundle = make_bundle()
 
     result = runner.invoke(app, ["publish", str(bundle.root), "--token", "secret"])
 
@@ -651,9 +596,9 @@ def test_publish_rejects_an_invalid_bundle_before_reaching_the_api(
 
 
 def test_publish_uses_the_network_exit_code_when_the_api_is_unreachable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    bundle = _bundle(tmp_path / "bundle")
+    bundle = make_bundle()
     monkeypatch.setenv("BOOKSHELF_URL", UNREACHABLE_API)
 
     result = runner.invoke(app, ["publish", str(bundle.root)])
@@ -661,9 +606,9 @@ def test_publish_uses_the_network_exit_code_when_the_api_is_unreachable(
     assert result.exit_code == EXIT_NETWORK
 
 
-def test_recorded_and_validated_bundle_hashes_agree(tmp_path: Path) -> None:
+def test_recorded_and_validated_bundle_hashes_agree(make_bundle: BundleFactory) -> None:
     """The hash a caller validates is the hash publish drafts against."""
-    bundle = _bundle(tmp_path / "bundle")
+    bundle = make_bundle()
     client = _FakeClient(status="draft")
 
     validated = runner.invoke(app, ["validate", str(bundle.root), "--json"])
@@ -677,25 +622,16 @@ def test_recorded_and_validated_bundle_hashes_agree(tmp_path: Path) -> None:
     assert _payload(published.stdout)["bundle_hash"] == _payload(validated.stdout)["bundle_hash"]
 
 
-def test_tracking_ids_round_trip_as_uuids(tmp_path: Path) -> None:
-    bundle = _bundle(tmp_path / "bundle")
-
-    reloaded = Bundle.read(bundle.root)
-
-    assert isinstance(reloaded.manifest.resources[0].tracking_id, UUID)
-
-
 def test_publish_sends_the_recorded_data_dictionary_on_the_draft(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The dictionary has to ride on the CLI's own draft call.
 
     That draft is keyed on the bundle hash, so the replay underneath resumes it
     and never reapplies the framing.
     """
-    bundle = Bundle(tmp_path / "bundle")
-    bundle.set_book(
-        BundleBook(
+    bundle = make_bundle(
+        book=BundleBook(
             volume="example",
             version="v1.0.0",
             visibility="public",
@@ -703,13 +639,6 @@ def test_publish_sends_the_recorded_data_dictionary_on_the_draft(
             data_dictionary=[{"name": "region", "type": "string", "role": "dimension"}],
         )
     )
-    data = b"payload"
-    resource = bundle.add_resource(
-        data=data, hash_=sha256_hex(data), type_="document", tracking_id=uuid4()
-    )
-    bundle.add_book_entry(name_in_book="entry-0", tracking_id=resource.tracking_id)
-    bundle.mark_book_published()
-    bundle.write()
 
     client = _FakeClient(status="draft")
     _patch_publish(monkeypatch, client, edition=2)


### PR DESCRIPTION
Bundle is the on-disk artefact a recorded build produces and publishing consumes, but the rules that decide whether a bundle is valid lived in the CLI as `_check_bundle` and `_require_framing`. The module could therefore hand out records that broke its own contract, and nothing but `CliRunner` could ask whether a bundle was sound. The knowledge was already next door: Bundle hashes, does referential checks on `add_book_entry`, and owns the path-traversal defence on `resource_filename`. This is that knowledge going home.

## What changed

- Moves the five invariants onto `Bundle.validate`: a book framing is recorded, the book is marked published, the book has entries, every entry references a recorded resource, and every managed resource's bytes still hash to the recorded hash.
- Raises the typed `InvalidBundleError`, a `BookshelfError` subclass carrying the detail the CLI renders. One catch reaches every refusal.
- Adds `Bundle.require_framing` and `Bundle.read_validated`, so a caller reads and asserts in one call.
- Shrinks `_cli/producer.py` to rendering. `_bundle_errors` catches the typed error and picks the exit code. `_check_bundle` and `_require_framing` are gone.
- Fixes the stale docstring reference to `bookshelf.publisher._models.ActivityCreate`. No such class exists. The wire shape it mirrors is `bookshelf._generated.models.ActivityEnvelope`.

`compute_book_bundle_hash` is untouched. It is the cross-system idempotency seal and must stay byte-identical to the backend's `_compute_bundle_hash`.

## The interface is now the test surface

`tests/test_bundle.py` is the first direct test the module has ever had. It covers the five invariants, the pointer case that must not be re-hashed, and the unvalidated read, all through the `Bundle` interface with no `CliRunner`. `tests/test_cli_producer.py` is thinned to what is genuinely CLI: exit codes and rendering.

`tests/conftest.py` is new, the first in the repository. It carries a bundle factory, replacing the hand-built bundle that `test_cli_producer.py` was maintaining on its own.

## Why `read` stays unvalidated

`Bundle.read` is left structural and `read_validated` is the explicit validating form, because two callers genuinely need the unvalidated read:

- `publisher/replay.py` loads a bundle to replay it, and a bundle recorded as a draft must replay as a draft.
- `bookshelf publish` asks only for the framing for the same reason.

## `bookshelf validate` is unchanged

Run against real bundles on disk before and after the change. The output is byte-identical.

Before:

```
$ bookshelf validate BUNDLE
Bundle        /tmp/scratchpad/bundle
Bundle hash   44eda8b2c5f1a1119f2d9dac0111aa54a96b1d3f768679114af63d3a5af2bcd9
Resources     1
Entries       1
Publishes     True
exit=0

$ bookshelf validate DRAFT
Error: bundle does not record a publish operation. Run 'bookshelf record' to rebuild the bundle.
exit=7

$ bookshelf validate NO-FRAMING
Error: bundle has no book framing. Run 'bookshelf record' to rebuild the bundle.
exit=7

$ bookshelf validate TAMPERED
Error: resource 11111111-1111-1111-1111-111111111111 has hash sha256:0b50c169..., got sha256:d121be31.... Run 'bookshelf record' to rebuild the bundle.
exit=7

$ bookshelf validate ORPHAN-ENTRY
Error: book entry 'entry-0' has no resource. Run 'bookshelf record' to rebuild the bundle.
exit=7

$ bookshelf validate ABSENT
Error: cannot read a bundle at /tmp/scratchpad/absent: [Errno 2] No such file or directory: '/tmp/scratchpad/absent/manifest.lock'. Run 'bookshelf record' to build one.
exit=7
```

After: identical, `diff` reports no difference across all six invocations plus `--json`.

Two paths deliberately changed. Both are cases where the re-hashing used to run outside the CLI's error mapping, so the failure escaped as a traceback and exit 1. A managed resource whose byte file is absent, and a crafted manifest whose resource hash is not canonical, are now bundle invariants like the others:

```
$ bookshelf validate NO-BYTES
Error: resource 11111111-1111-1111-1111-111111111111 has no bytes in the bundle: [Errno 2] No such file or directory: '.../resources/0b50c169....bin'. Run 'bookshelf record' to rebuild the bundle.
exit=7

$ bookshelf validate CRAFTED-HASH
Error: resource 11111111-1111-1111-1111-111111111111 has a non-canonical hash 'sha256:../../etc/passwd'. Run 'bookshelf record' to rebuild the bundle.
exit=7
```

The second is the path-traversal defence. It refused the read before and it refuses it now, but the refusal is reported as the invariant it is rather than as an unreadable bundle.

## Checks

- `make checks` exits 0 (pre-commit passes, mypy reports no issues in 52 source files).
- `make test` passes, 476 tests.
