### PR TITLE
refactor: remove the produce facade pass-through

### DIFF
--- a/changelog/160.trivial.md
+++ b/changelog/160.trivial.md
@@ -1,5 +1,6 @@
-Removed the producer facade pass-through beneath `Bookshelf` and `AsyncBookshelf`.
-Both classes now bind `activity`, `register_external` and `draft_book` to the adapter that serves
-them, so the calls, their parameters and their behaviour are unchanged.
-`visibility=` on `draft_book` now accepts the same input as every other registration surface and
-defaults to the adapter's own tier, which is `hidden` as before.
+Removes the producer facade pass-through beneath `Bookshelf` and `AsyncBookshelf`.
+
+- Both classes bind `activity`, `register_external` and `draft_book` to the adapter that serves them,
+  so the calls behave exactly as they did.
+- `visibility=` on `draft_book` accepts the same input as every other registration surface now,
+  and defaults to the adapter's own tier, which is `hidden` as before.

--- a/changelog/160.trivial.md
+++ b/changelog/160.trivial.md
@@ -1,3 +1,5 @@
 Removed the producer facade pass-through beneath `Bookshelf` and `AsyncBookshelf`.
-The two classes now bind `activity`, `register_external` and `draft_book` straight to the adapter
-that serves them, which leaves the public interface and its defaults unchanged.
+Both classes now bind `activity`, `register_external` and `draft_book` to the adapter that serves
+them, so the calls, their parameters and their behaviour are unchanged.
+`visibility=` on `draft_book` now accepts the same input as every other registration surface and
+defaults to the adapter's own tier, which is `hidden` as before.

--- a/changelog/160.trivial.md
+++ b/changelog/160.trivial.md
@@ -1,0 +1,3 @@
+Removed the producer facade pass-through beneath `Bookshelf` and `AsyncBookshelf`.
+The two classes now bind `activity`, `register_external` and `draft_book` straight to the adapter
+that serves them, which leaves the public interface and its defaults unchanged.

--- a/packages/bookshelf/src/bookshelf/_produce/__init__.py
+++ b/packages/bookshelf/src/bookshelf/_produce/__init__.py
@@ -2,7 +2,6 @@
 
 from bookshelf._produce.activities import Activity, AsyncActivity
 from bookshelf._produce.books import AsyncDraftBook, DraftBook
-from bookshelf._produce.facade import AsyncProduceFacade, ProduceFacade
 from bookshelf._produce.types import (
     PartialRegistrationError,
     RegisterItem,
@@ -15,10 +14,8 @@ __all__ = [
     "Activity",
     "AsyncActivity",
     "AsyncDraftBook",
-    "AsyncProduceFacade",
     "DraftBook",
     "PartialRegistrationError",
-    "ProduceFacade",
     "RegisterItem",
     "RegistrationFailure",
     "RegistrationSuccess",

--- a/packages/bookshelf/src/bookshelf/_produce/facade.py
+++ b/packages/bookshelf/src/bookshelf/_produce/facade.py
@@ -45,7 +45,7 @@ from bookshelf._produce.visibility import INHERIT, VisibilityInput
 from bookshelf.cache import ContentCache
 
 
-def _wrapped[T: RootModel[str]](model: type[T], value: str | None) -> T | None:
+def _as_model[T: RootModel[str]](model: type[T], value: str | None) -> T | None:
     """Wrap an optional string in the model its request field takes.
 
     An omitted value stays ``None`` so it never reaches the wire.
@@ -96,12 +96,12 @@ def _draft_request(
         series_name=volume,
         version=version,
         description=description,
-        citation_doi=_wrapped(models.CitationDoi, citation_doi),
-        license=_wrapped(models.License, license),
+        citation_doi=_as_model(models.CitationDoi, citation_doi),
+        license=_as_model(models.License, license),
         visibility=visibility,
         metadata=dict(metadata or {}),
         data_dictionary=list(data_dictionary or []),
-        bundle_hash=_wrapped(models.BundleHash, bundle_hash),
+        bundle_hash=_as_model(models.BundleHash, bundle_hash),
     )
 
 
@@ -196,9 +196,9 @@ class LiveSink:
     ) -> DraftBook:
         """Create a mutable draft whose membership changes remain intentional calls.
 
-        ``data_dictionary=`` describes the columns of the book's tabular and
-        timeseries entries. It is applied when the draft is created, so a call
-        that resumes an existing book through ``bundle_hash`` leaves the stored
+        ``data_dictionary=`` describes the columns of the book's tabular and timeseries entries.
+        It is applied when the draft is created,
+        so a call that resumes an existing book through ``bundle_hash`` leaves the stored
         dictionary untouched.
         """
         detail = self._client.draft_book(
@@ -308,9 +308,9 @@ class AsyncLiveSink:
     ) -> AsyncDraftBook:
         """Create an asynchronous mutable draft book handle.
 
-        ``data_dictionary=`` describes the columns of the book's tabular and
-        timeseries entries. It is applied when the draft is created, so a call
-        that resumes an existing book through ``bundle_hash`` leaves the stored
+        ``data_dictionary=`` describes the columns of the book's tabular and timeseries entries.
+        It is applied when the draft is created,
+        so a call that resumes an existing book through ``bundle_hash`` leaves the stored
         dictionary untouched.
         """
         detail = await self._client.draft_book_async(

--- a/packages/bookshelf/src/bookshelf/_produce/facade.py
+++ b/packages/bookshelf/src/bookshelf/_produce/facade.py
@@ -1,10 +1,12 @@
-"""Producer methods mixed into the public Bookshelf facades."""
+"""Producer write adapters and the seam the public facades bind to."""
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Awaitable, Mapping, Sequence
 from typing import Any, Protocol
 from uuid import UUID
+
+from pydantic import RootModel
 
 from bookshelf._core.client import BookshelfClient
 from bookshelf._generated import models
@@ -41,6 +43,66 @@ from bookshelf._produce.provenance import derive_code_ref
 from bookshelf._produce.resources import AsyncResource, Resource
 from bookshelf._produce.visibility import INHERIT, VisibilityInput
 from bookshelf.cache import ContentCache
+
+
+def _wrapped[T: RootModel[str]](model: type[T], value: str | None) -> T | None:
+    """Wrap an optional string in the model its request field takes.
+
+    An omitted value stays ``None`` so it never reaches the wire.
+    """
+    return None if value is None else model(value)
+
+
+def _register_item(
+    *,
+    type: str | models.ResourceType,
+    uri: str,
+    hash: str | None,
+    logical_key: str | None,
+    visibility: models.Visibility,
+    tags: Sequence[str],
+    metadata: Mapping[str, Any] | None,
+    tracking_id: UUID | None,
+    dedupe: bool,
+) -> models.RegisterResourceItem:
+    """Build the single-item registration an external pointer becomes."""
+    return models.RegisterResourceItem(
+        tracking_id=tracking_id or _uuid7(),
+        type=_resource_type(type),
+        hash=hash,
+        logical_key=logical_key,
+        visibility=visibility,
+        tags=list(tags),
+        metadata=dict(metadata or {}),
+        external_uri=uri,
+        dedupe=dedupe,
+    )
+
+
+def _draft_request(
+    volume: str,
+    *,
+    version: str,
+    description: str | None,
+    citation_doi: str | None,
+    license: str | None,
+    visibility: models.Visibility,
+    metadata: Mapping[str, Any] | None,
+    data_dictionary: Sequence[models.DataDictionaryEntry] | None,
+    bundle_hash: str | None,
+) -> models.BookDraftRequest:
+    """Build the draft request, wrapping each optional string the API takes as a model."""
+    return models.BookDraftRequest(
+        series_name=volume,
+        version=version,
+        description=description,
+        citation_doi=_wrapped(models.CitationDoi, citation_doi),
+        license=_wrapped(models.License, license),
+        visibility=visibility,
+        metadata=dict(metadata or {}),
+        data_dictionary=list(data_dictionary or []),
+        bundle_hash=_wrapped(models.BundleHash, bundle_hash),
+    )
 
 
 class LiveSink:
@@ -94,16 +156,15 @@ class LiveSink:
         dedupe: bool = True,
     ) -> Resource:
         """Catalogue an external pointer without attributing it to an activity."""
-        resource_type = _resource_type(type)
-        item = models.RegisterResourceItem(
-            tracking_id=tracking_id or _uuid7(),
-            type=resource_type,
+        item = _register_item(
+            type=type,
+            uri=uri,
             hash=hash,
             logical_key=logical_key,
             visibility=_visibility(visibility, self.default_visibility),
-            tags=list(tags),
-            metadata=dict(metadata or {}),
-            external_uri=uri,
+            tags=tags,
+            metadata=metadata,
+            tracking_id=tracking_id,
             dedupe=dedupe,
         )
         response = self._client.register_resources(
@@ -116,7 +177,7 @@ class LiveSink:
             self._client,
             self._cache,
             _registered_tracking_id(outcome),
-            resource_type=_registered_resource_type(outcome, resource_type),
+            resource_type=_registered_resource_type(outcome, item.type),
             registration_outcome=outcome,
         )
 
@@ -128,27 +189,29 @@ class LiveSink:
         description: str | None = None,
         citation_doi: str | None = None,
         license: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         metadata: Mapping[str, Any] | None = None,
         data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
         bundle_hash: str | None = None,
     ) -> DraftBook:
-        """Create a mutable draft whose membership changes remain intentional calls."""
+        """Create a mutable draft whose membership changes remain intentional calls.
+
+        ``data_dictionary=`` describes the columns of the book's tabular and
+        timeseries entries. It is applied when the draft is created, so a call
+        that resumes an existing book through ``bundle_hash`` leaves the stored
+        dictionary untouched.
+        """
         detail = self._client.draft_book(
-            models.BookDraftRequest(
-                series_name=volume,
+            _draft_request(
+                volume,
                 version=version,
                 description=description,
-                citation_doi=(
-                    models.CitationDoi(root=citation_doi) if citation_doi is not None else None
-                ),
-                license=models.License(root=license) if license is not None else None,
-                visibility=_visibility(visibility),
-                metadata=dict(metadata or {}),
-                data_dictionary=list(data_dictionary or []),
-                bundle_hash=(
-                    models.BundleHash(root=bundle_hash) if bundle_hash is not None else None
-                ),
+                citation_doi=citation_doi,
+                license=license,
+                visibility=_visibility(visibility, self.default_visibility),
+                metadata=metadata,
+                data_dictionary=data_dictionary,
+                bundle_hash=bundle_hash,
             )
         )
         return DraftBook(self._client, detail)
@@ -205,16 +268,15 @@ class AsyncLiveSink:
         dedupe: bool = True,
     ) -> AsyncResource:
         """Catalogue an external pointer without attributing it to an activity."""
-        resource_type = _resource_type(type)
-        item = models.RegisterResourceItem(
-            tracking_id=tracking_id or _uuid7(),
-            type=resource_type,
+        item = _register_item(
+            type=type,
+            uri=uri,
             hash=hash,
             logical_key=logical_key,
             visibility=_visibility(visibility, self.default_visibility),
-            tags=list(tags),
-            metadata=dict(metadata or {}),
-            external_uri=uri,
+            tags=tags,
+            metadata=metadata,
+            tracking_id=tracking_id,
             dedupe=dedupe,
         )
         response = await self._client.register_resources_async(
@@ -227,7 +289,7 @@ class AsyncLiveSink:
             self._client,
             self._cache,
             _registered_tracking_id(outcome),
-            resource_type=_registered_resource_type(outcome, resource_type),
+            resource_type=_registered_resource_type(outcome, item.type),
             registration_outcome=outcome,
         )
 
@@ -239,34 +301,40 @@ class AsyncLiveSink:
         description: str | None = None,
         citation_doi: str | None = None,
         license: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
+        visibility: VisibilityInput = INHERIT,
         metadata: Mapping[str, Any] | None = None,
         data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
         bundle_hash: str | None = None,
     ) -> AsyncDraftBook:
-        """Create an asynchronous mutable draft book handle."""
+        """Create an asynchronous mutable draft book handle.
+
+        ``data_dictionary=`` describes the columns of the book's tabular and
+        timeseries entries. It is applied when the draft is created, so a call
+        that resumes an existing book through ``bundle_hash`` leaves the stored
+        dictionary untouched.
+        """
         detail = await self._client.draft_book_async(
-            models.BookDraftRequest(
-                series_name=volume,
+            _draft_request(
+                volume,
                 version=version,
                 description=description,
-                citation_doi=(
-                    models.CitationDoi(root=citation_doi) if citation_doi is not None else None
-                ),
-                license=models.License(root=license) if license is not None else None,
-                visibility=_visibility(visibility),
-                metadata=dict(metadata or {}),
-                data_dictionary=list(data_dictionary or []),
-                bundle_hash=(
-                    models.BundleHash(root=bundle_hash) if bundle_hash is not None else None
-                ),
+                citation_doi=citation_doi,
+                license=license,
+                visibility=_visibility(visibility, self.default_visibility),
+                metadata=metadata,
+                data_dictionary=data_dictionary,
+                bundle_hash=bundle_hash,
             )
         )
         return AsyncDraftBook(self._client, detail)
 
 
-class ProduceSink(Protocol):
-    """Adapter interface for synchronous producer writes."""
+class _ProduceSink[ActivityT, ResourceT, DraftT](Protocol):
+    """Adapter interface for producer writes, parameterised by what each call hands back.
+
+    The synchronous adapters return their handles directly.
+    The asynchronous ones return an awaitable for the two calls that reach the API.
+    """
 
     def activity(
         self,
@@ -277,7 +345,7 @@ class ProduceSink(Protocol):
         runner: str | None = None,
         activity_id: UUID | None = None,
         config_hash: str | None = None,
-    ) -> Activity: ...
+    ) -> ActivityT: ...
 
     def register_external(
         self,
@@ -291,7 +359,7 @@ class ProduceSink(Protocol):
         metadata: Mapping[str, Any] | None = None,
         tracking_id: UUID | None = None,
         dedupe: bool = True,
-    ) -> Resource: ...
+    ) -> ResourceT: ...
 
     def draft_book(
         self,
@@ -301,229 +369,23 @@ class ProduceSink(Protocol):
         description: str | None = None,
         citation_doi: str | None = None,
         license: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
-        metadata: Mapping[str, Any] | None = None,
-        data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
-        bundle_hash: str | None = None,
-    ) -> DraftBook: ...
-
-
-class AsyncProduceSink(Protocol):
-    """Adapter interface for asynchronous producer writes."""
-
-    def activity(
-        self,
-        *,
-        code_ref: str | None = None,
-        config: Mapping[str, Any] | None = None,
-        kind: str = "run",
-        runner: str | None = None,
-        activity_id: UUID | None = None,
-        config_hash: str | None = None,
-    ) -> AsyncActivity: ...
-
-    async def register_external(
-        self,
-        *,
-        type: str | models.ResourceType,
-        uri: str,
-        hash: str | None = None,
-        logical_key: str | None = None,
         visibility: VisibilityInput = INHERIT,
-        tags: Sequence[str] = (),
-        metadata: Mapping[str, Any] | None = None,
-        tracking_id: UUID | None = None,
-        dedupe: bool = True,
-    ) -> AsyncResource: ...
-
-    async def draft_book(
-        self,
-        volume: str,
-        *,
-        version: str,
-        description: str | None = None,
-        citation_doi: str | None = None,
-        license: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
         metadata: Mapping[str, Any] | None = None,
         data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
         bundle_hash: str | None = None,
-    ) -> AsyncDraftBook: ...
+    ) -> DraftT: ...
 
 
-class ProduceFacade:
-    """Synchronous producer operations layered onto the consume facade."""
+ProduceSink = _ProduceSink[Activity, Resource, DraftBook]
+"""The synchronous producer seam, satisfied by :class:`LiveSink` and the recording adapter."""
 
-    _produce_sink: ProduceSink
-
-    def activity(
-        self,
-        *,
-        code_ref: str | None = None,
-        config: Mapping[str, Any] | None = None,
-        kind: str = "run",
-        runner: str | None = None,
-        activity_id: UUID | None = None,
-        config_hash: str | None = None,
-    ) -> Activity:
-        """Open an ambient producer activity."""
-        return self._produce_sink.activity(
-            code_ref=code_ref,
-            config=config,
-            kind=kind,
-            runner=runner,
-            activity_id=activity_id,
-            config_hash=config_hash,
-        )
-
-    def register_external(
-        self,
-        *,
-        type: str | models.ResourceType,
-        uri: str,
-        hash: str | None = None,
-        logical_key: str | None = None,
-        visibility: VisibilityInput = INHERIT,
-        tags: Sequence[str] = (),
-        metadata: Mapping[str, Any] | None = None,
-        tracking_id: UUID | None = None,
-        dedupe: bool = True,
-    ) -> Resource:
-        """Catalogue an external pointer through the active sink."""
-        return self._produce_sink.register_external(
-            type=type,
-            uri=uri,
-            hash=hash,
-            logical_key=logical_key,
-            visibility=visibility,
-            tags=tags,
-            metadata=metadata,
-            tracking_id=tracking_id,
-            dedupe=dedupe,
-        )
-
-    def draft_book(
-        self,
-        volume: str,
-        *,
-        version: str,
-        description: str | None = None,
-        citation_doi: str | None = None,
-        license: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
-        metadata: Mapping[str, Any] | None = None,
-        data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
-        bundle_hash: str | None = None,
-    ) -> DraftBook:
-        """Create a draft through the active sink.
-
-        ``data_dictionary=`` describes the columns of the book's tabular and
-        timeseries entries. It is applied when the draft is created, so a call
-        that resumes an existing book through ``bundle_hash`` leaves the stored
-        dictionary untouched.
-        """
-        return self._produce_sink.draft_book(
-            volume,
-            version=version,
-            description=description,
-            citation_doi=citation_doi,
-            license=license,
-            visibility=visibility,
-            metadata=metadata,
-            data_dictionary=data_dictionary,
-            bundle_hash=bundle_hash,
-        )
-
-
-class AsyncProduceFacade:
-    """Asynchronous producer operations layered onto the consume facade."""
-
-    _produce_sink: AsyncProduceSink
-
-    def activity(
-        self,
-        *,
-        code_ref: str | None = None,
-        config: Mapping[str, Any] | None = None,
-        kind: str = "run",
-        runner: str | None = None,
-        activity_id: UUID | None = None,
-        config_hash: str | None = None,
-    ) -> AsyncActivity:
-        """Open an ambient asynchronous producer activity."""
-        return self._produce_sink.activity(
-            code_ref=code_ref,
-            config=config,
-            kind=kind,
-            runner=runner,
-            activity_id=activity_id,
-            config_hash=config_hash,
-        )
-
-    async def register_external(
-        self,
-        *,
-        type: str | models.ResourceType,
-        uri: str,
-        hash: str | None = None,
-        logical_key: str | None = None,
-        visibility: VisibilityInput = INHERIT,
-        tags: Sequence[str] = (),
-        metadata: Mapping[str, Any] | None = None,
-        tracking_id: UUID | None = None,
-        dedupe: bool = True,
-    ) -> AsyncResource:
-        """Catalogue an external pointer through the active sink."""
-        return await self._produce_sink.register_external(
-            type=type,
-            uri=uri,
-            hash=hash,
-            logical_key=logical_key,
-            visibility=visibility,
-            tags=tags,
-            metadata=metadata,
-            tracking_id=tracking_id,
-            dedupe=dedupe,
-        )
-
-    async def draft_book(
-        self,
-        volume: str,
-        *,
-        version: str,
-        description: str | None = None,
-        citation_doi: str | None = None,
-        license: str | None = None,
-        visibility: str | models.Visibility = models.Visibility.hidden,
-        metadata: Mapping[str, Any] | None = None,
-        data_dictionary: Sequence[models.DataDictionaryEntry] | None = None,
-        bundle_hash: str | None = None,
-    ) -> AsyncDraftBook:
-        """Create a draft through the active sink.
-
-        ``data_dictionary=`` describes the columns of the book's tabular and
-        timeseries entries. It is applied when the draft is created, so a call
-        that resumes an existing book through ``bundle_hash`` leaves the stored
-        dictionary untouched.
-        """
-        return await self._produce_sink.draft_book(
-            volume,
-            version=version,
-            description=description,
-            citation_doi=citation_doi,
-            license=license,
-            visibility=visibility,
-            metadata=metadata,
-            data_dictionary=data_dictionary,
-            bundle_hash=bundle_hash,
-        )
+AsyncProduceSink = _ProduceSink[AsyncActivity, Awaitable[AsyncResource], Awaitable[AsyncDraftBook]]
+"""The asynchronous producer seam."""
 
 
 __all__ = [
     "AsyncLiveSink",
-    "AsyncProduceFacade",
     "AsyncProduceSink",
     "LiveSink",
-    "ProduceFacade",
     "ProduceSink",
 ]

--- a/packages/bookshelf/src/bookshelf/_produce/facade.py
+++ b/packages/bookshelf/src/bookshelf/_produce/facade.py
@@ -198,8 +198,8 @@ class LiveSink:
 
         ``data_dictionary=`` describes the columns of the book's tabular and timeseries entries.
         It is applied when the draft is created,
-        so a call that resumes an existing book through ``bundle_hash`` leaves the stored
-        dictionary untouched.
+        so a call that resumes an existing book through ``bundle_hash``
+        leaves the stored dictionary untouched.
         """
         detail = self._client.draft_book(
             _draft_request(
@@ -310,8 +310,8 @@ class AsyncLiveSink:
 
         ``data_dictionary=`` describes the columns of the book's tabular and timeseries entries.
         It is applied when the draft is created,
-        so a call that resumes an existing book through ``bundle_hash`` leaves the stored
-        dictionary untouched.
+        so a call that resumes an existing book through ``bundle_hash``
+        leaves the stored dictionary untouched.
         """
         detail = await self._client.draft_book_async(
             _draft_request(

--- a/packages/bookshelf/src/bookshelf/facade.py
+++ b/packages/bookshelf/src/bookshelf/facade.py
@@ -153,16 +153,13 @@ class Bookshelf:
             transport=transport,
         )
         self._cache = ContentCache()
-        self._bind_produce_sink(LiveSink(self._client, self._cache))
-
-    def _bind_produce_sink(self, sink: ProduceSink) -> None:
-        """Point the producer surface at an adapter.
-
-        A recording build swaps the adapter after construction, so the bound calls move with it.
-        """
+        sink: ProduceSink = LiveSink(self._client, self._cache)
         self.activity = sink.activity
+        """Open an ambient producer activity with deterministic provenance."""
         self.register_external = sink.register_external
+        """Catalogue an external pointer without attributing it to an activity."""
         self.draft_book = sink.draft_book
+        """Create a mutable draft whose membership changes remain intentional calls."""
 
     def __enter__(self) -> Self:
         return self
@@ -338,13 +335,13 @@ class AsyncBookshelf:
             async_transport=async_transport,
         )
         self._cache = ContentCache()
-        self._bind_produce_sink(AsyncLiveSink(self._client, self._cache))
-
-    def _bind_produce_sink(self, sink: AsyncProduceSink) -> None:
-        """Point the producer surface at an adapter."""
+        sink: AsyncProduceSink = AsyncLiveSink(self._client, self._cache)
         self.activity = sink.activity
+        """Open an ambient asynchronous producer activity."""
         self.register_external = sink.register_external
+        """Catalogue an external pointer without attributing it to an activity."""
         self.draft_book = sink.draft_book
+        """Create an asynchronous mutable draft book handle."""
 
     async def __aenter__(self) -> Self:
         return self

--- a/packages/bookshelf/src/bookshelf/facade.py
+++ b/packages/bookshelf/src/bookshelf/facade.py
@@ -153,6 +153,7 @@ class Bookshelf:
             transport=transport,
         )
         self._cache = ContentCache()
+        # A subclass changes these by rebinding them after this runs, not by redefining them.
         sink: ProduceSink = LiveSink(self._client, self._cache)
         self.activity = sink.activity
         """Open an ambient producer activity with deterministic provenance."""

--- a/packages/bookshelf/src/bookshelf/facade.py
+++ b/packages/bookshelf/src/bookshelf/facade.py
@@ -32,7 +32,12 @@ from bookshelf._produce import (
     RegistrationSuccess,
     Used,
 )
-from bookshelf._produce.facade import AsyncLiveSink, AsyncProduceFacade, LiveSink, ProduceFacade
+from bookshelf._produce.facade import (
+    AsyncLiveSink,
+    AsyncProduceSink,
+    LiveSink,
+    ProduceSink,
+)
 from bookshelf.cache import ContentCache
 
 _PAGE_SIZE = 100
@@ -129,7 +134,7 @@ def _missing_book(volume: str, version: str, edition: int | None) -> NotFoundErr
     )
 
 
-class Bookshelf(ProduceFacade):
+class Bookshelf:
     """Synchronous facade for consuming, cataloguing, and curating resources."""
 
     def __init__(
@@ -148,7 +153,16 @@ class Bookshelf(ProduceFacade):
             transport=transport,
         )
         self._cache = ContentCache()
-        self._produce_sink = LiveSink(self._client, self._cache)
+        self._bind_produce_sink(LiveSink(self._client, self._cache))
+
+    def _bind_produce_sink(self, sink: ProduceSink) -> None:
+        """Point the producer surface at an adapter.
+
+        A recording build swaps the adapter after construction, so the bound calls move with it.
+        """
+        self.activity = sink.activity
+        self.register_external = sink.register_external
+        self.draft_book = sink.draft_book
 
     def __enter__(self) -> Self:
         return self
@@ -305,7 +319,7 @@ class Bookshelf(ProduceFacade):
         raise BookshelfError("book entry lookup exceeded the pagination safety cap")
 
 
-class AsyncBookshelf(AsyncProduceFacade):
+class AsyncBookshelf:
     """Asynchronous facade for consuming, cataloguing, and curating resources."""
 
     def __init__(
@@ -324,7 +338,13 @@ class AsyncBookshelf(AsyncProduceFacade):
             async_transport=async_transport,
         )
         self._cache = ContentCache()
-        self._produce_sink = AsyncLiveSink(self._client, self._cache)
+        self._bind_produce_sink(AsyncLiveSink(self._client, self._cache))
+
+    def _bind_produce_sink(self, sink: AsyncProduceSink) -> None:
+        """Point the producer surface at an adapter."""
+        self.activity = sink.activity
+        self.register_external = sink.register_external
+        self.draft_book = sink.draft_book
 
     async def __aenter__(self) -> Self:
         return self

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -637,7 +637,11 @@ class RecordingBookshelf(Bookshelf):
             self._cache,
             authors=authors,
         )
-        self._bind_produce_sink(self.recording_sink)
+        # Every producer call moves to the recording adapter, so reads stay live and writes
+        # land in the bundle.
+        self.activity = self.recording_sink.activity
+        self.register_external = self.recording_sink.register_external
+        self.draft_book = self.recording_sink.draft_book
 
 
 @dataclass(slots=True)

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -637,8 +637,8 @@ class RecordingBookshelf(Bookshelf):
             self._cache,
             authors=authors,
         )
-        # Every producer call moves to the recording adapter, so reads stay live and writes
-        # land in the bundle.
+        # Every producer call moves to the recording adapter,
+        # so reads stay live and writes land in the bundle.
         self.activity = self.recording_sink.activity
         self.register_external = self.recording_sink.register_external
         self.draft_book = self.recording_sink.draft_book

--- a/packages/bookshelf/src/bookshelf/publisher/record.py
+++ b/packages/bookshelf/src/bookshelf/publisher/record.py
@@ -637,7 +637,7 @@ class RecordingBookshelf(Bookshelf):
             self._cache,
             authors=authors,
         )
-        self._produce_sink = self.recording_sink
+        self._bind_produce_sink(self.recording_sink)
 
 
 @dataclass(slots=True)

--- a/packages/bookshelf/tests/test_facade_produce.py
+++ b/packages/bookshelf/tests/test_facade_produce.py
@@ -1,0 +1,190 @@
+"""The producer surface the public facades bind to, reached through the facade itself."""
+
+import inspect
+import json
+from typing import Any
+from uuid import UUID
+
+import httpx
+import pytest
+
+from bookshelf._core.errors import BookshelfError
+from bookshelf._generated import models
+from bookshelf._produce.facade import AsyncLiveSink, LiveSink
+from bookshelf.facade import AsyncBookshelf, Bookshelf
+from bookshelf.publisher.record import RecordingSink
+from tests import _core_payloads as payloads
+
+BASE_URL = "https://bookshelf.test"
+TRACKING_ID = "0197a000-0000-7000-8000-000000000001"
+
+REGISTERED_ONE: dict[str, Any] = {
+    "activity_created": False,
+    "atomic": True,
+    "registered": [
+        {
+            "index": 0,
+            "status": "created",
+            "outcome": {"status": "created", "tracking_id": TRACKING_ID},
+        }
+    ],
+}
+
+
+def _transport(recorded: list[httpx.Request], status: int, payload: Any) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorded.append(request)
+        return httpx.Response(status, json=payload)
+
+    return httpx.MockTransport(handler)
+
+
+def _body(request: httpx.Request) -> dict[str, Any]:
+    return json.loads(request.content)  # type: ignore[no-any-return]
+
+
+def _sync(recorded: list[httpx.Request], status: int, payload: Any) -> Bookshelf:
+    return Bookshelf(BASE_URL, auth=None, transport=_transport(recorded, status, payload))
+
+
+def _async(recorded: list[httpx.Request], status: int, payload: Any) -> AsyncBookshelf:
+    return AsyncBookshelf(
+        BASE_URL, auth=None, async_transport=_transport(recorded, status, payload)
+    )
+
+
+def test_draft_book_wraps_the_optional_strings_the_api_takes_as_models() -> None:
+    """The DOI, the licence and the bundle hash each arrive as a plain string on the wire."""
+    recorded: list[httpx.Request] = []
+
+    with _sync(recorded, 201, payloads.BOOK_DETAIL) as client:
+        draft = client.draft_book(
+            "primap-hist",
+            version="1.0.0",
+            citation_doi="10.5281/zenodo.1",
+            license="CC-BY-4.0",
+            bundle_hash="a" * 64,
+            data_dictionary=[models.DataDictionaryEntry(name="region", role="dimension")],
+        )
+
+    assert draft.metadata.series_name == "primap-hist"
+    request = recorded[0]
+    assert (request.method, request.url.path) == ("POST", "/v1/books")
+    body = _body(request)
+    assert body["citation_doi"] == "10.5281/zenodo.1"
+    assert body["license"] == "CC-BY-4.0"
+    assert body["bundle_hash"] == "a" * 64
+    assert body["data_dictionary"] == [{"name": "region", "role": "dimension"}]
+
+
+def test_draft_book_sends_no_wrapper_for_an_omitted_string() -> None:
+    """An omitted DOI, licence or bundle hash stays null rather than arriving as an empty model."""
+    recorded: list[httpx.Request] = []
+
+    with _sync(recorded, 201, payloads.BOOK_DETAIL) as client:
+        client.draft_book("primap-hist", version="1.0.0")
+
+    body = _body(recorded[0])
+    assert body["citation_doi"] is None
+    assert body["license"] is None
+    assert body["bundle_hash"] is None
+    assert body["visibility"] == "hidden"
+
+
+def test_draft_book_carries_an_explicit_tier() -> None:
+    recorded: list[httpx.Request] = []
+
+    with _sync(recorded, 201, payloads.BOOK_DETAIL) as client:
+        client.draft_book("primap-hist", version="1.0.0", visibility="public")
+
+    assert _body(recorded[0])["visibility"] == "public"
+
+
+def test_register_external_catalogues_the_pointer() -> None:
+    recorded: list[httpx.Request] = []
+
+    with _sync(recorded, 200, REGISTERED_ONE) as client:
+        resource = client.register_external(
+            type="tabular",
+            uri="https://example.invalid/data.csv",
+            logical_key="raw/data.csv",
+            tags=["raw"],
+        )
+
+    assert resource.tracking_id == UUID(TRACKING_ID)
+    request = recorded[0]
+    assert (request.method, request.url.path) == ("POST", "/v1/resources/registrations")
+    item = _body(request)["items"][0]
+    assert item["external_uri"] == "https://example.invalid/data.csv"
+    assert item["type"] == "tabular"
+    assert item["logical_key"] == "raw/data.csv"
+    assert item["tags"] == ["raw"]
+    assert item["visibility"] == "hidden"
+
+
+def test_register_external_raises_when_the_batch_comes_back_empty() -> None:
+    recorded: list[httpx.Request] = []
+
+    with (
+        _sync(recorded, 200, payloads.REGISTERED) as client,
+        pytest.raises(BookshelfError, match="no registration outcome"),
+    ):
+        client.register_external(type="tabular", uri="https://example.invalid/data.csv")
+
+
+async def test_the_async_producer_surface_matches_the_sync_one() -> None:
+    drafted: list[httpx.Request] = []
+    async with _async(drafted, 201, payloads.BOOK_DETAIL) as client:
+        draft = await client.draft_book(
+            "primap-hist",
+            version="1.0.0",
+            license="CC-BY-4.0",
+        )
+    assert draft.metadata.series_name == "primap-hist"
+    assert _body(drafted[0])["license"] == "CC-BY-4.0"
+
+    registered: list[httpx.Request] = []
+    async with _async(registered, 200, REGISTERED_ONE) as client:
+        resource = await client.register_external(
+            type="tabular",
+            uri="https://example.invalid/data.csv",
+        )
+    assert resource.tracking_id == UUID(TRACKING_ID)
+    assert _body(registered[0])["items"][0]["external_uri"] == "https://example.invalid/data.csv"
+
+
+def test_the_facade_binds_the_activity_call_to_the_sink() -> None:
+    """``bs.activity`` is the sink's own call, so a swapped adapter takes the traffic."""
+    recorded: list[httpx.Request] = []
+
+    with _sync(recorded, 201, payloads.BOOK_DETAIL) as client:
+        activity = client.activity(kind="build", code_ref="test", config={"a": 1})
+
+    assert activity.kind == "build"
+    assert recorded == []
+
+
+@pytest.mark.parametrize("call", ["activity", "register_external", "draft_book"])
+def test_the_live_and_recording_adapters_declare_the_same_call(call: str) -> None:
+    """The two adapters substitute for each other, so a caller cannot tell them apart."""
+    live = inspect.signature(getattr(LiveSink, call))
+    recording = inspect.signature(getattr(RecordingSink, call))
+
+    assert [
+        (name, parameter.kind, parameter.default) for name, parameter in live.parameters.items()
+    ] == [
+        (name, parameter.kind, parameter.default)
+        for name, parameter in recording.parameters.items()
+    ]
+
+
+@pytest.mark.parametrize("call", ["activity", "register_external", "draft_book"])
+def test_the_two_live_adapters_declare_the_same_call(call: str) -> None:
+    sync = inspect.signature(getattr(LiveSink, call))
+    async_ = inspect.signature(getattr(AsyncLiveSink, call))
+
+    assert [
+        (name, parameter.kind, parameter.default) for name, parameter in sync.parameters.items()
+    ] == [
+        (name, parameter.kind, parameter.default) for name, parameter in async_.parameters.items()
+    ]

--- a/packages/bookshelf/tests/test_facade_produce.py
+++ b/packages/bookshelf/tests/test_facade_produce.py
@@ -2,6 +2,7 @@
 
 import inspect
 import json
+from pathlib import Path
 from typing import Any
 from uuid import UUID
 
@@ -12,7 +13,8 @@ from bookshelf._core.errors import BookshelfError
 from bookshelf._generated import models
 from bookshelf._produce.facade import AsyncLiveSink, LiveSink
 from bookshelf.facade import AsyncBookshelf, Bookshelf
-from bookshelf.publisher.record import RecordingSink
+from bookshelf.publisher.bundle import Bundle
+from bookshelf.publisher.record import RecordingBookshelf, RecordingSink
 from tests import _core_payloads as payloads
 
 BASE_URL = "https://bookshelf.test"
@@ -164,27 +166,31 @@ def test_the_facade_binds_the_activity_call_to_the_sink() -> None:
     assert recorded == []
 
 
+def _parameters(adapter: type, call: str) -> list[tuple[str, Any, Any]]:
+    """Name, kind and default of every parameter an adapter's call takes."""
+    signature = inspect.signature(getattr(adapter, call))
+    return [
+        (name, parameter.kind, parameter.default)
+        for name, parameter in signature.parameters.items()
+    ]
+
+
 @pytest.mark.parametrize("call", ["activity", "register_external", "draft_book"])
 def test_the_live_and_recording_adapters_declare_the_same_call(call: str) -> None:
     """The two adapters substitute for each other, so a caller cannot tell them apart."""
-    live = inspect.signature(getattr(LiveSink, call))
-    recording = inspect.signature(getattr(RecordingSink, call))
-
-    assert [
-        (name, parameter.kind, parameter.default) for name, parameter in live.parameters.items()
-    ] == [
-        (name, parameter.kind, parameter.default)
-        for name, parameter in recording.parameters.items()
-    ]
+    assert _parameters(LiveSink, call) == _parameters(RecordingSink, call)
 
 
 @pytest.mark.parametrize("call", ["activity", "register_external", "draft_book"])
 def test_the_two_live_adapters_declare_the_same_call(call: str) -> None:
-    sync = inspect.signature(getattr(LiveSink, call))
-    async_ = inspect.signature(getattr(AsyncLiveSink, call))
+    assert _parameters(LiveSink, call) == _parameters(AsyncLiveSink, call)
 
-    assert [
-        (name, parameter.kind, parameter.default) for name, parameter in sync.parameters.items()
-    ] == [
-        (name, parameter.kind, parameter.default) for name, parameter in async_.parameters.items()
-    ]
+
+def test_a_recording_facade_binds_every_producer_call_to_its_bundle(tmp_path: Path) -> None:
+    """A recorded build keeps live reads, so only the three producer calls move to the bundle."""
+    bundle = Bundle(tmp_path / "bundle")
+
+    with RecordingBookshelf(bundle) as recording:
+        bound = [recording.activity, recording.register_external, recording.draft_book]
+
+    assert [call.__self__ for call in bound] == [recording.recording_sink] * 3

--- a/packages/bookshelf/tests/test_facade_produce.py
+++ b/packages/bookshelf/tests/test_facade_produce.py
@@ -11,7 +11,7 @@ import pytest
 
 from bookshelf._core.errors import BookshelfError
 from bookshelf._generated import models
-from bookshelf._produce.facade import AsyncLiveSink, LiveSink
+from bookshelf._produce.facade import LiveSink
 from bookshelf.facade import AsyncBookshelf, Bookshelf
 from bookshelf.publisher.bundle import Bundle
 from bookshelf.publisher.record import RecordingBookshelf, RecordingSink
@@ -179,11 +179,6 @@ def _parameters(adapter: type, call: str) -> list[tuple[str, Any, Any]]:
 def test_the_live_and_recording_adapters_declare_the_same_call(call: str) -> None:
     """The two adapters substitute for each other, so a caller cannot tell them apart."""
     assert _parameters(LiveSink, call) == _parameters(RecordingSink, call)
-
-
-@pytest.mark.parametrize("call", ["activity", "register_external", "draft_book"])
-def test_the_two_live_adapters_declare_the_same_call(call: str) -> None:
-    assert _parameters(LiveSink, call) == _parameters(AsyncLiveSink, call)
 
 
 def test_a_recording_facade_binds_every_producer_call_to_its_bundle(tmp_path: Path) -> None:

--- a/packages/bookshelf/tests/test_facade_produce.py
+++ b/packages/bookshelf/tests/test_facade_produce.py
@@ -1,6 +1,8 @@
 """The producer surface the public facades bind to, reached through the facade itself."""
 
+import ast
 import inspect
+import itertools
 import json
 from pathlib import Path
 from typing import Any
@@ -9,6 +11,7 @@ from uuid import UUID
 import httpx
 import pytest
 
+import bookshelf.facade
 from bookshelf._core.errors import BookshelfError
 from bookshelf._generated import models
 from bookshelf._produce.facade import LiveSink
@@ -155,8 +158,8 @@ async def test_the_async_producer_surface_matches_the_sync_one() -> None:
     assert _body(registered[0])["items"][0]["external_uri"] == "https://example.invalid/data.csv"
 
 
-def test_the_facade_binds_the_activity_call_to_the_sink() -> None:
-    """``bs.activity`` is the sink's own call, so a swapped adapter takes the traffic."""
+def test_opening_an_activity_reaches_no_api() -> None:
+    """An activity is an ambient envelope, so nothing is written until a registration lands."""
     recorded: list[httpx.Request] = []
 
     with _sync(recorded, 201, payloads.BOOK_DETAIL) as client:
@@ -189,3 +192,27 @@ def test_a_recording_facade_binds_every_producer_call_to_its_bundle(tmp_path: Pa
         bound = [recording.activity, recording.register_external, recording.draft_book]
 
     assert [call.__self__ for call in bound] == [recording.recording_sink] * 3
+
+
+@pytest.mark.parametrize("facade", ["Bookshelf", "AsyncBookshelf"])
+def test_every_bound_producer_call_carries_a_docstring(facade: str) -> None:
+    """The API reference reads the binding in ``__init__``, so an undocumented one goes missing."""
+    source = Path(bookshelf.facade.__file__).read_text()
+    constructor = next(
+        node
+        for cls in ast.parse(source).body
+        if isinstance(cls, ast.ClassDef) and cls.name == facade
+        for node in cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    documented = {
+        target.attr: after.value.value
+        for assignment, after in itertools.pairwise(constructor.body)
+        if isinstance(assignment, ast.Assign)
+        for target in assignment.targets
+        if isinstance(target, ast.Attribute)
+        if isinstance(after, ast.Expr) and isinstance(after.value, ast.Constant)
+    }
+
+    assert {"activity", "register_external", "draft_book"} <= documented.keys()
+    assert all(documented[name].strip() for name in ("activity", "register_external", "draft_book"))

--- a/packages/bookshelf/tests/test_sync_async_parity.py
+++ b/packages/bookshelf/tests/test_sync_async_parity.py
@@ -24,8 +24,6 @@ from bookshelf import facade
 from bookshelf._consume import resources
 from bookshelf._produce import facade as produce
 
-# ``ProduceSink`` and ``AsyncProduceSink`` are two parameterisations of one declaration,
-# so there is no twin here that could drift.
 CLASS_PAIRS = [
     (facade.Bookshelf, facade.AsyncBookshelf),
     (produce.LiveSink, produce.AsyncLiveSink),

--- a/packages/bookshelf/tests/test_sync_async_parity.py
+++ b/packages/bookshelf/tests/test_sync_async_parity.py
@@ -24,11 +24,11 @@ from bookshelf import facade
 from bookshelf._consume import resources
 from bookshelf._produce import facade as produce
 
+# ``ProduceSink`` and ``AsyncProduceSink`` are two parameterisations of one declaration,
+# so there is no twin here that could drift.
 CLASS_PAIRS = [
     (facade.Bookshelf, facade.AsyncBookshelf),
     (produce.LiveSink, produce.AsyncLiveSink),
-    (produce.ProduceSink, produce.AsyncProduceSink),
-    (produce.ProduceFacade, produce.AsyncProduceFacade),
     (resources.Resource, resources.AsyncResource),
     (resources.BookEntry, resources.AsyncBookEntry),
 ]


### PR DESCRIPTION
Removes `ProduceFacade` and `AsyncProduceFacade`. They forwarded every argument to the sink beneath them and added no behaviour, so deleting them makes the complexity vanish rather than relocate it.

## What the modules were doing

`_produce/facade.py` stacked four things where two would do: the live adapters, the sink protocols, and 164 lines of pure forwarding on top. Every facade method restated its parameters and passed them straight through. `register_external` was 25 lines and 9 forwarded keywords with no logic. `draft_book` was 31 lines and 10 forwarded keywords with no logic. The async trio repeated all of it.

The cost was concentrated in one signature. `draft_book` takes ten parameters and it was written out seven times across the tree, so adding one was a seven-location edit.

## What changed

- Deletes both facades. `Bookshelf` and `AsyncBookshelf` bind `activity`, `register_external` and `draft_book` to the adapter that serves them, so the ten-parameter signature is no longer restated on the way through. The calls keep their parameters, their defaults and their types.
- Keeps the `ProduceSink` / `AsyncProduceSink` seam, which is real. `LiveSink` and `RecordingSink` are two genuinely different adapters, so the seam earns its keep. The two protocols become one declaration parameterised by what each call hands back, which means the seam names each call once instead of twice.
- Extracts the request building the two live adapters duplicated. The null-wrapping triple for the DOI, the licence and the bundle hash lives in one helper now, as does the single-item registration an external pointer becomes.
- Makes the recording adapter and the live one agree on `visibility=`. The protocol declared `str | models.Visibility = models.Visibility.hidden` while `RecordingSink` declared `VisibilityInput = INHERIT` in the same slot. Both take `VisibilityInput` and default to `INHERIT` now, which resolves to the adapter's own default. Nothing in the tree builds a live adapter with a non-hidden default, so the live default stays `hidden` and nothing observable moves.

## Two places where the brief and the result differ

Worth a maintainer's eye rather than a silent choice:

- **The signature count lands on four, not three.** It appears once on the seam and once in each of the three adapters. Three is only reachable by collapsing the sync and async implementations into one, which is a separate decision that stays deferred, or by dropping the seam, which is the one thing here worth keeping.
- **The three producer calls are bound attributes, not methods on the class.** That is what removes the restatement, but it moves them off the class object: `hasattr(Bookshelf, "draft_book")` is now `False`, so `help(Bookshelf)` does not list them and a subclass cannot override one by defining it (`RecordingBookshelf` rebinds instead, which is the supported route). They are bound in `__init__` with their own docstrings, so the mkdocstrings API reference still carries all three, as attributes rather than as signatures. Calls, types and mypy inference are unaffected. If losing the class-level surface is not an acceptable trade, the alternative is three explicit delegating `def`s per facade, which puts the signature back to six places.

## Tests

Adds `test_facade_produce.py`. Nothing previously reached `bs.draft_book` or `bs.register_external` through the facade against a transport, so the request-building rule this PR moves had no direct cover at all. The new tests reach both calls through the public facade on both surfaces and assert what lands on the wire, including the wrapped optional strings, the omitted ones, and the resolved tier. Two of them pin the adapters to a common signature, which is the defect above stated as a test, and one pins a recording facade to its bundle-backed adapter.

`test_facade_lifecycle.py` passes unmodified.

`test_sync_async_parity.py` arrived on the base branch while this was in flight and loses two of its pairs. The produce facades it named are gone. The two sink protocols are two parameterisations of one declaration now, so neither pair has a twin left that could drift. The three producer calls stay guarded through the `LiveSink` / `AsyncLiveSink` pair it already carries, plus the live-against-recording check added here.

## Notes

- `_produce/__init__.py` had to drop its two re-exports of the deleted facades. It is a one-line consequence of the deletion rather than a change in its own right.
- `test_oauth.py::test_authorization_code_flow_surfaces_provider_error` and `::test_exchange_failure_raises` fail intermittently under the random test ordering. This reproduces on the base branch without these changes, so it is left alone.
