### PR TITLE
refactor: move the publish decision behind a publisher interface

### DIFF
--- a/changelog/161.improvement.md
+++ b/changelog/161.improvement.md
@@ -1,0 +1,11 @@
+Publishing a recorded bundle now happens behind `bookshelf.publisher.publish_bundle`,
+which drafts once, decides, and returns a `PublishOutcome`
+carrying the kind, the edition, the resource count and the bundle hash.
+
+A publish previously drafted twice,
+because the `bookshelf publish` implementation drafted to decide what to do
+and `replay_bundle_sync` drafted again underneath it.
+`replay_bundle` and `replay_bundle_sync` now accept an already-resolved draft,
+so a caller that drafted to decide does not draft a second time.
+
+`bookshelf publish` and `bookshelf publish --dry-run` produce the same output and the same exit codes as before.

--- a/changelog/161.improvement.md
+++ b/changelog/161.improvement.md
@@ -8,4 +8,5 @@ and `replay_bundle_sync` drafted again underneath it.
 `replay_bundle` and `replay_bundle_sync` now accept an already-resolved draft,
 so a caller that drafted to decide does not draft a second time.
 
-`bookshelf publish` and `bookshelf publish --dry-run` produce the same output and the same exit codes as before.
+`bookshelf publish` and `bookshelf publish --dry-run` produce the same output,
+and the same exit codes, as before.

--- a/packages/bookshelf/src/bookshelf/_cli/producer.py
+++ b/packages/bookshelf/src/bookshelf/_cli/producer.py
@@ -46,10 +46,10 @@ from bookshelf.publisher import (
     compute_book_bundle_hash,
     load_record_recipe,
     parse_parameters,
-    replay_bundle_sync,
+    publish_bundle,
     run_record,
 )
-from bookshelf.publisher.bundle import InvalidBundleError, book_data_dictionary
+from bookshelf.publisher.bundle import InvalidBundleError
 
 _RECORD_REQUIREMENTS = ("papermill", "nbconvert")
 _PAGE_SIZE = 100
@@ -263,44 +263,17 @@ def publish(
         with _bundle_errors(bundle):
             loaded = Bundle.read(bundle)
             framing = loaded.require_framing()
-        bundle_hash = compute_book_bundle_hash(loaded.manifest)
 
         with Bookshelf(resolve_base_url(api_url)) as client:
-            drafted = client.draft_book(
-                framing.volume,
-                version=framing.version,
-                description=framing.description,
-                citation_doi=framing.citation_doi,
-                license=framing.license,
-                visibility=framing.visibility,
-                metadata=framing.metadata,
-                # This draft is keyed on the bundle hash, so the replay below
-                # resumes it rather than reapplying the framing. The dictionary
-                # has to travel on this call or it never reaches the book.
-                data_dictionary=book_data_dictionary(framing),
-                bundle_hash=bundle_hash,
-            )
-            # Drafting is the only way to learn whether the edition already exists,
-            # and it is keyed on the bundle hash, so a dry run adds no edition of its own.
-            if drafted.status == "published":
-                outcome, edition, resources = "no-op", drafted.metadata.edition, 0
-            elif dry_run:
-                outcome = "would-publish"
-                edition = drafted.metadata.edition
-                resources = len(loaded.manifest.resources)
-            else:
-                published = replay_bundle_sync(loaded, client)
-                outcome = "published"
-                edition = published.metadata.edition
-                resources = len(loaded.manifest.resources)
+            outcome = publish_bundle(loaded, client, dry_run=dry_run)
 
         summary = {
-            "outcome": outcome,
+            "outcome": outcome.kind,
             "volume": framing.volume,
             "version": framing.version,
-            "edition": edition,
-            "bundle_hash": bundle_hash,
-            "resources": resources,
+            "edition": outcome.edition,
+            "bundle_hash": outcome.bundle_hash,
+            "resources": outcome.resources,
         }
         _emit_summary(summary, _PUBLISH_LABELS, json_output=json_output)
 

--- a/packages/bookshelf/src/bookshelf/publisher/__init__.py
+++ b/packages/bookshelf/src/bookshelf/publisher/__init__.py
@@ -40,6 +40,20 @@ Synchronous applications use :func:`replay_bundle_sync` with :class:`bookshelf.B
 
     with Bookshelf() as bs:
         book = replay_bundle_sync(Path("bundle"), bs)
+
+Use :func:`publish_bundle` to publish a recorded bundle rather than to replay one::
+
+    from pathlib import Path
+
+    from bookshelf import Bookshelf
+    from bookshelf.publisher import Bundle, publish_bundle
+
+    with Bookshelf() as bs:
+        outcome = publish_bundle(Bundle.read(Path("bundle")), bs)
+
+It returns what the publish resolved to,
+so a caller can report an edition that already exists
+without having to compare a draft against a replay itself.
 """
 
 from bookshelf.publisher.bundle import (
@@ -54,6 +68,7 @@ from bookshelf.publisher.lock import (
     mask_aggregate_lock,
     mask_lock,
 )
+from bookshelf.publisher.publish import PublishKind, PublishOutcome, publish_bundle
 from bookshelf.publisher.recipe import Recipe, RecipeBook, load_recipe
 from bookshelf.publisher.record import (
     RecordedDraftBook,
@@ -74,6 +89,8 @@ __all__ = [
     "AggregateLock",
     "Bundle",
     "BundleManifest",
+    "PublishKind",
+    "PublishOutcome",
     "RecordRecipe",
     "Recipe",
     "RecipeBook",
@@ -91,6 +108,7 @@ __all__ = [
     "mask_aggregate_lock",
     "mask_lock",
     "parse_parameters",
+    "publish_bundle",
     "replay_bundle",
     "replay_bundle_sync",
     "run_record",

--- a/packages/bookshelf/src/bookshelf/publisher/__init__.py
+++ b/packages/bookshelf/src/bookshelf/publisher/__init__.py
@@ -41,19 +41,11 @@ Synchronous applications use :func:`replay_bundle_sync` with :class:`bookshelf.B
     with Bookshelf() as bs:
         book = replay_bundle_sync(Path("bundle"), bs)
 
-Use :func:`publish_bundle` to publish a recorded bundle rather than to replay one::
-
-    from pathlib import Path
-
-    from bookshelf import Bookshelf
-    from bookshelf.publisher import Bundle, publish_bundle
+Use :func:`publish_bundle` to publish a recorded bundle rather than to replay one.
+It returns a :class:`PublishOutcome` saying what the publish resolved to::
 
     with Bookshelf() as bs:
         outcome = publish_bundle(Bundle.read(Path("bundle")), bs)
-
-It returns what the publish resolved to,
-so a caller can report an edition that already exists
-without having to compare a draft against a replay itself.
 """
 
 from bookshelf.publisher.bundle import (
@@ -68,7 +60,7 @@ from bookshelf.publisher.lock import (
     mask_aggregate_lock,
     mask_lock,
 )
-from bookshelf.publisher.publish import PublishKind, PublishOutcome, publish_bundle
+from bookshelf.publisher.publish import PublishOutcome, publish_bundle
 from bookshelf.publisher.recipe import Recipe, RecipeBook, load_recipe
 from bookshelf.publisher.record import (
     RecordedDraftBook,
@@ -89,7 +81,6 @@ __all__ = [
     "AggregateLock",
     "Bundle",
     "BundleManifest",
-    "PublishKind",
     "PublishOutcome",
     "RecordRecipe",
     "Recipe",

--- a/packages/bookshelf/src/bookshelf/publisher/publish.py
+++ b/packages/bookshelf/src/bookshelf/publisher/publish.py
@@ -11,7 +11,7 @@ PublishKind = Literal["no-op", "would-publish", "published"]
 """What a publish did: nothing, nothing yet, or a replay through to publication."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PublishOutcome:
     """What publishing a bundle resolved to.
 
@@ -49,11 +49,26 @@ def publish_bundle(bundle: Bundle, bs: Bookshelf, *, dry_run: bool = False) -> P
     resources = len(bundle.manifest.resources)
     drafted = draft_bundle_book_sync(bundle, bs)
     if drafted.status == "published":
-        return PublishOutcome("no-op", drafted.metadata.edition, 0, bundle_hash)
+        return PublishOutcome(
+            kind="no-op",
+            edition=drafted.metadata.edition,
+            resources=0,
+            bundle_hash=bundle_hash,
+        )
     if dry_run:
-        return PublishOutcome("would-publish", drafted.metadata.edition, resources, bundle_hash)
+        return PublishOutcome(
+            kind="would-publish",
+            edition=drafted.metadata.edition,
+            resources=resources,
+            bundle_hash=bundle_hash,
+        )
     published = replay_bundle_sync(bundle, bs, draft=drafted)
-    return PublishOutcome("published", published.metadata.edition, resources, bundle_hash)
+    return PublishOutcome(
+        kind="published",
+        edition=published.metadata.edition,
+        resources=resources,
+        bundle_hash=bundle_hash,
+    )
 
 
 __all__ = ["PublishKind", "PublishOutcome", "publish_bundle"]

--- a/packages/bookshelf/src/bookshelf/publisher/publish.py
+++ b/packages/bookshelf/src/bookshelf/publisher/publish.py
@@ -1,0 +1,59 @@
+"""Decide what publishing a recorded bundle should do, and do it."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+from bookshelf.facade import Bookshelf
+from bookshelf.publisher.bundle import Bundle, compute_book_bundle_hash
+from bookshelf.publisher.replay import draft_bundle_book_sync, replay_bundle_sync
+
+PublishKind = Literal["no-op", "would-publish", "published"]
+"""What a publish did: nothing, nothing yet, or a replay through to publication."""
+
+
+@dataclass(frozen=True)
+class PublishOutcome:
+    """What publishing a bundle resolved to.
+
+    ``resources`` counts what the publish replayed,
+    so it is zero for an edition that already exists.
+    ``bundle_hash`` is the key the edition converges on.
+    """
+
+    kind: PublishKind
+    edition: int
+    resources: int
+    bundle_hash: str
+
+
+def publish_bundle(bundle: Bundle, bs: Bookshelf, *, dry_run: bool = False) -> PublishOutcome:
+    """Replay a recorded bundle to publish it, converging on one edition.
+
+    Drafting is the only way to learn whether the edition already exists,
+    and the draft is keyed on the bundle hash,
+    so a dry run adds no edition of its own.
+    The draft this decision rests on is the one the replay resumes.
+
+    Args:
+        bundle: Loaded bundle to publish.
+        bs: Open synchronous client used for the draft and the replay.
+        dry_run: Resolve the edition and report the outcome without replaying.
+
+    Returns:
+        What the publish resolved to.
+
+    Raises:
+        ValueError: The bundle has no book framing or contains an invalid resource representation.
+    """
+    bundle_hash = compute_book_bundle_hash(bundle.manifest)
+    resources = len(bundle.manifest.resources)
+    drafted = draft_bundle_book_sync(bundle, bs)
+    if drafted.status == "published":
+        return PublishOutcome("no-op", drafted.metadata.edition, 0, bundle_hash)
+    if dry_run:
+        return PublishOutcome("would-publish", drafted.metadata.edition, resources, bundle_hash)
+    published = replay_bundle_sync(bundle, bs, draft=drafted)
+    return PublishOutcome("published", published.metadata.edition, resources, bundle_hash)
+
+
+__all__ = ["PublishKind", "PublishOutcome", "publish_bundle"]

--- a/packages/bookshelf/src/bookshelf/publisher/replay.py
+++ b/packages/bookshelf/src/bookshelf/publisher/replay.py
@@ -12,6 +12,7 @@ from bookshelf._produce.types import Used, UsedInput
 from bookshelf.facade import AsyncBookshelf, Bookshelf
 from bookshelf.publisher.bundle import (
     Bundle,
+    BundleBook,
     BundleResource,
     BundleUsedRef,
     book_data_dictionary,
@@ -19,9 +20,68 @@ from bookshelf.publisher.bundle import (
 )
 
 
+def _book_framing(bundle: Bundle) -> BundleBook:
+    book = bundle.manifest.book
+    if book is None:
+        raise ValueError("bundle has no book framing")
+    return book
+
+
+async def draft_bundle_book(bundle: Bundle, bs: AsyncBookshelf) -> AsyncDraftBook:
+    """Draft the bundle's book through an asynchronous Bookshelf client.
+
+    The draft is keyed on the bundle hash,
+    so drafting is how a caller learns whether the edition already exists.
+    The data dictionary has to travel on this call or it never reaches the book.
+
+    Args:
+        bundle: Loaded bundle carrying the book framing.
+        bs: Open asynchronous client used for the draft.
+
+    Returns:
+        The existing published book or the draft to replay into.
+
+    Raises:
+        ValueError: The bundle has no book framing.
+    """
+    book = _book_framing(bundle)
+    return await bs.draft_book(
+        book.volume,
+        version=book.version,
+        description=book.description,
+        citation_doi=book.citation_doi,
+        visibility=book.visibility,
+        license=book.license,
+        metadata=book.metadata,
+        data_dictionary=book_data_dictionary(book),
+        bundle_hash=compute_book_bundle_hash(bundle.manifest),
+    )
+
+
+def draft_bundle_book_sync(bundle: Bundle, bs: Bookshelf) -> DraftBook:
+    """Draft the bundle's book through a synchronous Bookshelf client.
+
+    This is the synchronous counterpart to :func:`draft_bundle_book`.
+    """
+    book = _book_framing(bundle)
+    return bs.draft_book(
+        book.volume,
+        version=book.version,
+        description=book.description,
+        citation_doi=book.citation_doi,
+        visibility=book.visibility,
+        license=book.license,
+        metadata=book.metadata,
+        data_dictionary=book_data_dictionary(book),
+        bundle_hash=compute_book_bundle_hash(bundle.manifest),
+    )
+
+
 async def replay_bundle(
     bundle: Path | Bundle,
     bs: AsyncBookshelf,
+    *,
+    draft: AsyncDraftBook | None = None,
 ) -> AsyncDraftBook:
     """Replay a recorded bundle through an asynchronous Bookshelf client.
 
@@ -39,6 +99,8 @@ async def replay_bundle(
     Args:
         bundle: Bundle directory or an already loaded bundle.
         bs: Open asynchronous client used for all replay writes.
+        draft: Draft already resolved by :func:`draft_bundle_book`, so a caller that
+            drafted to decide what to do does not draft a second time.
 
     Returns:
         The existing published book or the draft populated by this replay.
@@ -48,22 +110,10 @@ async def replay_bundle(
     """
     recorded = Bundle.read(bundle) if isinstance(bundle, Path) else bundle
     manifest = recorded.manifest
-    book = manifest.book
-    if book is None:
-        raise ValueError("bundle has no book framing")
-    draft = await bs.draft_book(
-        book.volume,
-        version=book.version,
-        description=book.description,
-        citation_doi=book.citation_doi,
-        visibility=book.visibility,
-        license=book.license,
-        metadata=book.metadata,
-        data_dictionary=book_data_dictionary(book),
-        bundle_hash=compute_book_bundle_hash(manifest),
-    )
-    if draft.status == "published":
-        return draft
+    book = _book_framing(recorded)
+    resolved = draft if draft is not None else await draft_bundle_book(recorded, bs)
+    if resolved.status == "published":
+        return resolved
 
     resources: dict[UUID, AsyncResource] = {}
     generated = [resource for resource in manifest.resources if resource.generated]
@@ -129,20 +179,23 @@ async def replay_bundle(
         raise ValueError("generated bundle resources require a recorded activity")
 
     for entry in book.entries:
-        await draft.attach(resources[entry.tracking_id], name_in_book=entry.name_in_book)
+        await resolved.attach(resources[entry.tracking_id], name_in_book=entry.name_in_book)
     if book.published:
-        await draft.publish()
-    return draft
+        await resolved.publish()
+    return resolved
 
 
 def replay_bundle_sync(
     bundle: Path | Bundle,
     bs: Bookshelf,
+    *,
+    draft: DraftBook | None = None,
 ) -> DraftBook:
     """Replay a recorded bundle through a synchronous Bookshelf client.
 
     This is the synchronous counterpart to :func:`replay_bundle`.
-    It accepts the same path or loaded bundle forms.
+    It accepts the same path or loaded bundle forms,
+    and the same already-resolved draft.
     It preserves the same identifiers,
     lineage,
     draft-resume,
@@ -150,22 +203,10 @@ def replay_bundle_sync(
     """
     recorded = Bundle.read(bundle) if isinstance(bundle, Path) else bundle
     manifest = recorded.manifest
-    book = manifest.book
-    if book is None:
-        raise ValueError("bundle has no book framing")
-    draft = bs.draft_book(
-        book.volume,
-        version=book.version,
-        description=book.description,
-        citation_doi=book.citation_doi,
-        visibility=book.visibility,
-        license=book.license,
-        metadata=book.metadata,
-        data_dictionary=book_data_dictionary(book),
-        bundle_hash=compute_book_bundle_hash(manifest),
-    )
-    if draft.status == "published":
-        return draft
+    book = _book_framing(recorded)
+    resolved = draft if draft is not None else draft_bundle_book_sync(recorded, bs)
+    if resolved.status == "published":
+        return resolved
 
     resources: dict[UUID, Resource] = {}
     generated = [resource for resource in manifest.resources if resource.generated]
@@ -231,10 +272,10 @@ def replay_bundle_sync(
         raise ValueError("generated bundle resources require a recorded activity")
 
     for entry in book.entries:
-        draft.attach(resources[entry.tracking_id], name_in_book=entry.name_in_book)
+        resolved.attach(resources[entry.tracking_id], name_in_book=entry.name_in_book)
     if book.published:
-        draft.publish()
-    return draft
+        resolved.publish()
+    return resolved
 
 
 def _resource_used(
@@ -289,4 +330,4 @@ def _used_value(reference: BundleUsedRef) -> Used | UUID:
     raise ValueError("recorded used reference has no coordinate")
 
 
-__all__ = ["replay_bundle", "replay_bundle_sync"]
+__all__ = ["draft_bundle_book", "draft_bundle_book_sync", "replay_bundle", "replay_bundle_sync"]

--- a/packages/bookshelf/tests/test_cli_producer.py
+++ b/packages/bookshelf/tests/test_cli_producer.py
@@ -18,12 +18,14 @@ from bookshelf._cli._runtime import (
     EXIT_USAGE,
 )
 from bookshelf._core.client import BookshelfClient
+from bookshelf.facade import Bookshelf
 from bookshelf.publisher.bundle import (
     Bundle,
     BundleBook,
     compute_book_bundle_hash,
     resource_filename,
 )
+from bookshelf.publisher.publish import PublishOutcome
 from tests import _core_payloads as payloads
 from tests.conftest import BundleFactory
 
@@ -485,51 +487,27 @@ def test_discard_rejects_an_address_that_is_not_one_edition(
     assert recorded == []
 
 
-class _FakeDraft:
-    def __init__(self, status: str, edition: int) -> None:
-        self.status = status
-        self.metadata = type("Detail", (), {"edition": edition})()
-
-
-class _FakeClient:
-    """Stands in for the facade, recording whether replay was reached."""
-
-    def __init__(self, status: str = "draft", edition: int = 1) -> None:
-        self._status = status
-        self._edition = edition
-        self.draft_kwargs: dict[str, Any] = {}
-
-    def __enter__(self) -> "_FakeClient":
-        return self
-
-    def __exit__(self, *exc_info: object) -> None:
-        return None
-
-    def draft_book(self, volume: str, **kwargs: Any) -> _FakeDraft:
-        self.draft_kwargs = {"volume": volume, **kwargs}
-        return _FakeDraft(self._status, self._edition)
-
-
 def _patch_publish(
-    monkeypatch: pytest.MonkeyPatch, client: _FakeClient, *, edition: int = 2
-) -> list[Bundle]:
-    replayed: list[Bundle] = []
+    monkeypatch: pytest.MonkeyPatch, outcome: PublishOutcome
+) -> list[tuple[Bundle, bool]]:
+    """Answer the publisher with ``outcome``, recording the bundle and flag the command passed."""
+    calls: list[tuple[Bundle, bool]] = []
 
-    def fake_replay(bundle: Bundle, _client: Any) -> Any:
-        replayed.append(bundle)
-        return _FakeDraft("published", edition)
+    def fake_publish(bundle: Bundle, _client: Any, *, dry_run: bool = False) -> PublishOutcome:
+        calls.append((bundle, dry_run))
+        return outcome
 
-    monkeypatch.setattr("bookshelf._cli.producer.Bookshelf", lambda _url: client)
-    monkeypatch.setattr("bookshelf._cli.producer.replay_bundle_sync", fake_replay)
-    return replayed
+    monkeypatch.setenv("BOOKSHELF_URL", UNREACHABLE_API)
+    monkeypatch.setattr("bookshelf._cli.producer.publish_bundle", fake_publish)
+    return calls
 
 
-def test_publish_replays_and_reports_the_edition(
+def test_publish_renders_the_outcome(
     make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     bundle = make_bundle()
-    client = _FakeClient(status="draft")
-    replayed = _patch_publish(monkeypatch, client, edition=2)
+    outcome = PublishOutcome("published", 2, 1, "b" * 64)
+    calls = _patch_publish(monkeypatch, outcome)
 
     result = runner.invoke(app, ["publish", str(bundle.root), "--json"])
 
@@ -540,16 +518,15 @@ def test_publish_replays_and_reports_the_edition(
     assert summary["version"] == "v1.0.0"
     assert summary["edition"] == 2
     assert summary["resources"] == 1
-    assert len(replayed) == 1
-    assert client.draft_kwargs["bundle_hash"] == summary["bundle_hash"]
+    assert summary["bundle_hash"] == "b" * 64
+    assert [dry_run for _bundle_arg, dry_run in calls] == [False]
 
 
-def test_publish_reports_a_no_op_when_the_edition_exists(
+def test_publish_renders_a_no_op(
     make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     bundle = make_bundle()
-    client = _FakeClient(status="published", edition=3)
-    replayed = _patch_publish(monkeypatch, client)
+    _patch_publish(monkeypatch, PublishOutcome("no-op", 3, 0, "c" * 64))
 
     result = runner.invoke(app, ["publish", str(bundle.root), "--json"])
 
@@ -558,15 +535,13 @@ def test_publish_reports_a_no_op_when_the_edition_exists(
     assert summary["outcome"] == "no-op"
     assert summary["edition"] == 3
     assert summary["resources"] == 0
-    assert replayed == []
 
 
-def test_publish_dry_run_never_replays(
+def test_publish_dry_run_asks_the_publisher_not_to_write(
     make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     bundle = make_bundle()
-    client = _FakeClient(status="draft", edition=1)
-    replayed = _patch_publish(monkeypatch, client)
+    calls = _patch_publish(monkeypatch, PublishOutcome("would-publish", 1, 1, "d" * 64))
 
     result = runner.invoke(app, ["publish", str(bundle.root), "--dry-run", "--json"])
 
@@ -574,36 +549,7 @@ def test_publish_dry_run_never_replays(
     summary = _payload(result.stdout)
     assert summary["outcome"] == "would-publish"
     assert summary["edition"] == 1
-    assert replayed == []
-
-
-def test_publish_dry_run_reports_a_no_op_for_a_published_edition(
-    make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    bundle = make_bundle()
-    client = _FakeClient(status="published", edition=4)
-    _patch_publish(monkeypatch, client)
-
-    result = runner.invoke(app, ["publish", str(bundle.root), "--dry-run", "--json"])
-
-    assert result.exit_code == EXIT_OK
-    assert _payload(result.stdout)["outcome"] == "no-op"
-
-
-def test_publish_forwards_the_recorded_framing_to_the_draft(
-    make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    bundle = make_bundle()
-    client = _FakeClient(status="draft")
-    _patch_publish(monkeypatch, client)
-
-    result = runner.invoke(app, ["publish", str(bundle.root), "--json"])
-
-    assert result.exit_code == EXIT_OK
-    assert client.draft_kwargs["volume"] == "example"
-    assert client.draft_kwargs["version"] == "v1.0.0"
-    assert client.draft_kwargs["visibility"] == "public"
-    assert client.draft_kwargs["license"] == "MIT"
+    assert [dry_run for _bundle_arg, dry_run in calls] == [True]
 
 
 def test_publish_rejects_a_token_flag(make_bundle: BundleFactory) -> None:
@@ -638,46 +584,27 @@ def test_publish_uses_the_network_exit_code_when_the_api_is_unreachable(
     assert result.exit_code == EXIT_NETWORK
 
 
-def test_recorded_and_validated_bundle_hashes_agree(make_bundle: BundleFactory) -> None:
-    """The hash a caller validates is the hash publish drafts against."""
-    bundle = make_bundle()
-    client = _FakeClient(status="draft")
-
-    validated = runner.invoke(app, ["validate", str(bundle.root), "--json"])
-    assert validated.exit_code == EXIT_OK
-
-    with pytest.MonkeyPatch.context() as patch:
-        _patch_publish(patch, client)
-        published = runner.invoke(app, ["publish", str(bundle.root), "--json"])
-
-    assert published.exit_code == EXIT_OK
-    assert _payload(published.stdout)["bundle_hash"] == _payload(validated.stdout)["bundle_hash"]
-
-
-def test_publish_sends_the_recorded_data_dictionary_on_the_draft(
+def test_recorded_and_validated_bundle_hashes_agree(
     make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The dictionary has to ride on the CLI's own draft call.
+    """The hash a caller validates is the hash publish drafts against."""
+    bundle = make_bundle()
+    monkeypatch.setenv("BOOKSHELF_URL", UNREACHABLE_API)
+    recorded: list[httpx.Request] = []
 
-    That draft is keyed on the bundle hash, so the replay underneath resumes it
-    and never reapplies the framing.
-    """
-    bundle = make_bundle(
-        book=BundleBook(
-            volume="example",
-            version="v1.0.0",
-            visibility="public",
-            license="MIT",
-            data_dictionary=[{"name": "region", "type": "string", "role": "dimension"}],
-        )
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorded.append(request)
+        return httpx.Response(201, json=payloads.BOOK_DETAIL)
+
+    monkeypatch.setattr(
+        "bookshelf._cli.producer.Bookshelf",
+        lambda url: Bookshelf(url, auth=None, transport=httpx.MockTransport(handler)),
     )
 
-    client = _FakeClient(status="draft")
-    _patch_publish(monkeypatch, client, edition=2)
+    validated = runner.invoke(app, ["validate", str(bundle.root), "--json"])
+    published = runner.invoke(app, ["publish", str(bundle.root), "--dry-run", "--json"])
 
-    result = runner.invoke(app, ["publish", str(bundle.root), "--json"])
-
-    assert result.exit_code == EXIT_OK
-    sent = client.draft_kwargs["data_dictionary"]
-    assert [entry.name for entry in sent] == ["region"]
-    assert sent[0].role == "dimension"
+    assert (validated.exit_code, published.exit_code) == (EXIT_OK, EXIT_OK)
+    expected = _payload(validated.stdout)["bundle_hash"]
+    assert _payload(published.stdout)["bundle_hash"] == expected
+    assert json.loads(recorded[0].content)["bundle_hash"] == expected

--- a/packages/bookshelf/tests/test_cli_producer.py
+++ b/packages/bookshelf/tests/test_cli_producer.py
@@ -18,10 +18,8 @@ from bookshelf._cli._runtime import (
     EXIT_USAGE,
 )
 from bookshelf._core.client import BookshelfClient
-from bookshelf.facade import Bookshelf
 from bookshelf.publisher.bundle import (
     Bundle,
-    BundleBook,
     compute_book_bundle_hash,
     resource_filename,
 )
@@ -497,6 +495,8 @@ def _patch_publish(
         calls.append((bundle, dry_run))
         return outcome
 
+    # The command still builds a real client around the stubbed publisher,
+    # so point it somewhere that is not the production deployment.
     monkeypatch.setenv("BOOKSHELF_URL", UNREACHABLE_API)
     monkeypatch.setattr("bookshelf._cli.producer.publish_bundle", fake_publish)
     return calls
@@ -506,7 +506,7 @@ def test_publish_renders_the_outcome(
     make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     bundle = make_bundle()
-    outcome = PublishOutcome("published", 2, 1, "b" * 64)
+    outcome = PublishOutcome(kind="published", edition=2, resources=1, bundle_hash="b" * 64)
     calls = _patch_publish(monkeypatch, outcome)
 
     result = runner.invoke(app, ["publish", str(bundle.root), "--json"])
@@ -526,7 +526,9 @@ def test_publish_renders_a_no_op(
     make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     bundle = make_bundle()
-    _patch_publish(monkeypatch, PublishOutcome("no-op", 3, 0, "c" * 64))
+    _patch_publish(
+        monkeypatch, PublishOutcome(kind="no-op", edition=3, resources=0, bundle_hash="c" * 64)
+    )
 
     result = runner.invoke(app, ["publish", str(bundle.root), "--json"])
 
@@ -541,7 +543,10 @@ def test_publish_dry_run_asks_the_publisher_not_to_write(
     make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     bundle = make_bundle()
-    calls = _patch_publish(monkeypatch, PublishOutcome("would-publish", 1, 1, "d" * 64))
+    calls = _patch_publish(
+        monkeypatch,
+        PublishOutcome(kind="would-publish", edition=1, resources=1, bundle_hash="d" * 64),
+    )
 
     result = runner.invoke(app, ["publish", str(bundle.root), "--dry-run", "--json"])
 
@@ -582,29 +587,3 @@ def test_publish_uses_the_network_exit_code_when_the_api_is_unreachable(
     result = runner.invoke(app, ["publish", str(bundle.root)])
 
     assert result.exit_code == EXIT_NETWORK
-
-
-def test_recorded_and_validated_bundle_hashes_agree(
-    make_bundle: BundleFactory, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The hash a caller validates is the hash publish drafts against."""
-    bundle = make_bundle()
-    monkeypatch.setenv("BOOKSHELF_URL", UNREACHABLE_API)
-    recorded: list[httpx.Request] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        recorded.append(request)
-        return httpx.Response(201, json=payloads.BOOK_DETAIL)
-
-    monkeypatch.setattr(
-        "bookshelf._cli.producer.Bookshelf",
-        lambda url: Bookshelf(url, auth=None, transport=httpx.MockTransport(handler)),
-    )
-
-    validated = runner.invoke(app, ["validate", str(bundle.root), "--json"])
-    published = runner.invoke(app, ["publish", str(bundle.root), "--dry-run", "--json"])
-
-    assert (validated.exit_code, published.exit_code) == (EXIT_OK, EXIT_OK)
-    expected = _payload(validated.stdout)["bundle_hash"]
-    assert _payload(published.stdout)["bundle_hash"] == expected
-    assert json.loads(recorded[0].content)["bundle_hash"] == expected

--- a/packages/bookshelf/tests/test_publish_bundle.py
+++ b/packages/bookshelf/tests/test_publish_bundle.py
@@ -1,0 +1,184 @@
+"""Tests for ``publish_bundle``, driven against a mock transport rather than a stand-in client."""
+
+import json
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from bookshelf.facade import Bookshelf
+from bookshelf.publisher.bundle import Bundle, BundleBook, compute_book_bundle_hash
+from bookshelf.publisher.publish import publish_bundle
+from tests import _core_payloads as payloads
+
+BASE_URL = "https://bookshelf.test"
+POINTER_HASH = "sha256:" + "a" * 64
+
+
+def _bundle(
+    root: Path, *, tracking_id: UUID, data_dictionary: list[dict[str, str]] | None = None
+) -> Bundle:
+    """Write a replayable published book bundle carrying one external pointer."""
+    bundle = Bundle(root)
+    bundle.set_book(
+        BundleBook(
+            volume="example",
+            version="v1.0.0",
+            visibility="public",
+            license="MIT",
+            data_dictionary=data_dictionary or [],
+        )
+    )
+    bundle.add_pointer(
+        external_uri="https://example.test/data.csv",
+        hash_=POINTER_HASH,
+        type_="document",
+        tracking_id=tracking_id,
+    )
+    bundle.add_book_entry(name_in_book="data", tracking_id=tracking_id)
+    bundle.mark_book_published()
+    bundle.write()
+    return bundle
+
+
+def _book_detail(*, status: str, edition: int) -> dict[str, Any]:
+    return {**payloads.BOOK_DETAIL, "status": status, "edition": edition}
+
+
+def _client(recorded: list[httpx.Request], *, status: str = "draft", edition: int = 1) -> Bookshelf:
+    """Answer the four routes a publish walks, recording what it sent."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorded.append(request)
+        path = request.url.path
+        if path == "/v1/books":
+            return httpx.Response(201, json=_book_detail(status=status, edition=edition))
+        if path == "/v1/resources/registrations":
+            return httpx.Response(
+                200,
+                json={
+                    "activity_created": False,
+                    "atomic": True,
+                    "registered": [
+                        {
+                            "index": 0,
+                            "status": "created",
+                            "outcome": {
+                                "status": "created",
+                                "tracking_id": str(uuid4()),
+                            },
+                        }
+                    ],
+                },
+            )
+        if path.endswith("/entries"):
+            return httpx.Response(201, json=payloads.ENTRY_ATTACHED)
+        if path.endswith("/publish"):
+            return httpx.Response(200, json=_book_detail(status="published", edition=edition))
+        raise AssertionError(f"unexpected request to {path}")
+
+    return Bookshelf(BASE_URL, auth=None, transport=httpx.MockTransport(handler))
+
+
+def _drafts(recorded: list[httpx.Request]) -> list[httpx.Request]:
+    return [
+        request
+        for request in recorded
+        if request.method == "POST" and request.url.path == "/v1/books"
+    ]
+
+
+def test_publishing_replays_the_bundle_and_reports_the_edition(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path / "bundle", tracking_id=uuid4())
+    recorded: list[httpx.Request] = []
+
+    with _client(recorded, status="draft", edition=2) as client:
+        outcome = publish_bundle(bundle, client)
+
+    assert outcome.kind == "published"
+    assert outcome.edition == 2
+    assert outcome.resources == 1
+    assert [request.url.path for request in recorded][-1].endswith("/publish")
+
+
+def test_publishing_drafts_once(tmp_path: Path) -> None:
+    """The draft that decides the outcome is the draft the replay resumes."""
+    bundle = _bundle(tmp_path / "bundle", tracking_id=uuid4())
+    recorded: list[httpx.Request] = []
+
+    with _client(recorded) as client:
+        publish_bundle(bundle, client)
+
+    assert len(_drafts(recorded)) == 1
+
+
+def test_an_existing_published_edition_is_a_no_op(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path / "bundle", tracking_id=uuid4())
+    recorded: list[httpx.Request] = []
+
+    with _client(recorded, status="published", edition=3) as client:
+        outcome = publish_bundle(bundle, client)
+
+    assert outcome.kind == "no-op"
+    assert outcome.edition == 3
+    assert outcome.resources == 0
+    assert len(recorded) == 1, "a no-op writes nothing beyond the draft that reveals it"
+
+
+@pytest.mark.parametrize("status", ["draft", "published"])
+def test_a_dry_run_writes_nothing_beyond_the_draft(status: str, tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path / "bundle", tracking_id=uuid4())
+    recorded: list[httpx.Request] = []
+
+    with _client(recorded, status=status, edition=4) as client:
+        outcome = publish_bundle(bundle, client, dry_run=True)
+
+    assert outcome.kind == ("no-op" if status == "published" else "would-publish")
+    assert outcome.edition == 4
+    assert len(recorded) == 1
+
+
+def test_the_draft_carries_the_recorded_framing_and_the_bundle_hash(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path / "bundle", tracking_id=uuid4())
+    recorded: list[httpx.Request] = []
+
+    with _client(recorded) as client:
+        outcome = publish_bundle(bundle, client, dry_run=True)
+
+    body = json.loads(_drafts(recorded)[0].content)
+    assert body["series_name"] == "example"
+    assert body["version"] == "v1.0.0"
+    assert body["visibility"] == "public"
+    assert body["license"] == "MIT"
+    assert body["bundle_hash"] == outcome.bundle_hash
+    assert outcome.bundle_hash == compute_book_bundle_hash(bundle.manifest)
+
+
+def test_the_draft_carries_the_recorded_data_dictionary(tmp_path: Path) -> None:
+    """The dictionary is applied when the draft is created, so it has to ride on that call."""
+    bundle = _bundle(
+        tmp_path / "bundle",
+        tracking_id=uuid4(),
+        data_dictionary=[{"name": "region", "type": "string", "role": "dimension"}],
+    )
+    recorded: list[httpx.Request] = []
+
+    with _client(recorded) as client:
+        publish_bundle(bundle, client, dry_run=True)
+
+    sent = json.loads(_drafts(recorded)[0].content)["data_dictionary"]
+    assert [entry["name"] for entry in sent] == ["region"]
+    assert sent[0]["role"] == "dimension"
+
+
+def test_a_bundle_without_book_framing_is_refused(tmp_path: Path) -> None:
+    bundle = Bundle(tmp_path / "bundle")
+    bundle.write()
+    recorded: list[httpx.Request] = []
+
+    with _client(recorded) as client, pytest.raises(ValueError, match="no book framing"):
+        publish_bundle(bundle, client)
+
+    assert recorded == []


### PR DESCRIPTION
> **Stacked on lane C3.** This targets `refactor/bundle-owns-its-invariants` (#159) and should merge after it.

Publishing drafted twice per run, and its rules lived in a CLI private that only `CliRunner` could reach with both collaborators monkeypatched away. Now one interface returns an outcome, the CLI renders it, and the behaviour is tested against a real transport.

## What changed

- Adds `bookshelf.publisher.publish` with `publish_bundle` and `PublishOutcome`, the two names the package exports. The outcome carries the kind (`no-op`, `would-publish`, `published`), the edition, the resource count and the bundle hash. It is keyword-only, so the two adjacent integer fields cannot be transposed silently.
- Adds `draft_bundle_book` and `draft_bundle_book_sync` to `publisher/replay.py`, so the draft arguments live in one place rather than in both the CLI and the replay. The comment explaining why `data_dictionary` had to ride on the CLI's own call goes with them.
- `replay_bundle` and `replay_bundle_sync` accept an already-resolved draft, so a caller that drafted to decide does not draft again. The async twin stays in step with the sync one.
- Shrinks the `publish` command body to: read the bundle, call `publish_bundle`, render the outcome, pick an exit code.

## One draft per publish

The CLI drafted with 9 arguments and `replay_bundle_sync` then drafted again, so the idempotency behaviour of publishing was defined in two files. Running the real CLI against a stub deployment, before and after:

| run | before | after |
| --- | --- | --- |
| `bookshelf publish` | `POST /v1/books`, `POST /v1/books`, registrations, entries, publish | `POST /v1/books`, registrations, entries, publish |
| `bookshelf publish --dry-run` | `POST /v1/books` | `POST /v1/books` |
| `bookshelf publish` on an existing edition | `POST /v1/books` | `POST /v1/books` |

`test_publishing_drafts_once` asserts the count against the mock transport, so the property is now defended rather than observed.

## Unchanged output and exit codes

Same stub, same bundle, before and after.

`bookshelf publish`:

```
Outcome       published
Volume        example
Version       v1.0.0
Edition       7
Bundle hash   be62b7fe487b77fcd6cb5cd09995607ab788f3234c85a2f62e79ab46bb22a6fc
Resources     1
exit=0
```

`bookshelf publish --dry-run`:

```
Outcome       would-publish
Volume        example
Version       v1.0.0
Edition       7
Bundle hash   be62b7fe487b77fcd6cb5cd09995607ab788f3234c85a2f62e79ab46bb22a6fc
Resources     1
exit=0
```

`bookshelf publish` against a deployment that already holds the edition:

```
Outcome       no-op
Volume        example
Version       v1.0.0
Edition       7
Bundle hash   be62b7fe487b77fcd6cb5cd09995607ab788f3234c85a2f62e79ab46bb22a6fc
Resources     0
exit=0
```

## Tests

- Adds `tests/test_publish_bundle.py`, which drives `publish_bundle` against an `httpx.MockTransport` with no `CliRunner` and no monkeypatching of `Bookshelf`. It covers all three outcomes, the draft count, the framing and bundle hash on the draft, the data dictionary, and a bundle with no book framing.
- Removes `_FakeClient` and the `bookshelf._cli.producer.Bookshelf` and `bookshelf._cli.producer.replay_bundle_sync` monkeypatches from `test_cli_producer.py`. The CLI tests now assert rendering and exit codes only.
- The hash agreement between `validate` and `publish` is pinned at both ends against `compute_book_bundle_hash` rather than through a stand-in client: `test_validate_reports_the_bundle_summary` for one end and `test_the_draft_carries_the_recorded_framing_and_the_bundle_hash` for the other.

## Out of scope

- The sync and async twins in `replay.py` remain structurally identical modulo `await`. Collapsing them is a separate decision the maintainer has deferred.
- `compute_book_bundle_hash` and what it hashes are untouched.
